### PR TITLE
fix #294 - closing attributes dropdown without providing data possible

### DIFF
--- a/src/components/widget/Attributes/Attributes.js
+++ b/src/components/widget/Attributes/Attributes.js
@@ -134,7 +134,6 @@ class Attributes extends Component {
     }
 
     handleKeyDown = (e) => {
-        console.log(e.key);
         switch(e.key){
             case "Escape":
                 e.preventDefault();

--- a/src/components/widget/Attributes/Attributes.js
+++ b/src/components/widget/Attributes/Attributes.js
@@ -117,6 +117,16 @@ class Attributes extends Component {
         const {data} = this.state;
         const attrId = findRowByPropName(data, "ID").value;
 
+        const valid = data
+            .filter(field => field.mandatory)
+            .map(field => !!field.value)
+            .reduce((prev, current) => prev && current);
+
+        //required value is not set. just close
+        if (!valid){
+            return this.handleToggle(false);
+        }
+
         dispatch(completeRequest(attributeType, attrId)).then(response => {
             patch(response.data);
             this.handleToggle(false);
@@ -124,6 +134,7 @@ class Attributes extends Component {
     }
 
     handleKeyDown = (e) => {
+        console.log(e.key);
         switch(e.key){
             case "Escape":
                 e.preventDefault();


### PR DESCRIPTION
When required data is not provided just close, without saving