### PR TITLE
fix #311 - added extra space on table so to fit full hd

### DIFF
--- a/src/assets/css/table.css
+++ b/src/assets/css/table.css
@@ -380,5 +380,5 @@ $indent-signs-offset: 6px;
 }
 
 .document-list-table {
-    flex: 2.5;
+    flex: 2.6;
 }


### PR DESCRIPTION
Tested on osx and windows. Scrollbar appears on 1860px width of document