### PR TITLE
Major Sidelist error in receipt candidates #528

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -396,7 +396,7 @@ class Header extends Component {
                 />}
 
                 {showSidelist && isSideListShow && <SideList
-                    windowType={parseInt(windowType)}
+                    windowType={windowType ? parseInt(windowType) : ''}
                     closeOverlays={this.closeOverlays}
                     closeSideList={this.handleCloseSideList}
                     isSideListShow={isSideListShow}

--- a/src/containers/MasterWindow.js
+++ b/src/containers/MasterWindow.js
@@ -79,7 +79,7 @@ class MasterWindow extends Component {
     render() {
         const {
             master, modal, breadcrumb, references, actions, attachments,
-            rawModal, selected, indicator
+            rawModal, selected, indicator, params
         } = this.props;
 
         const {newRow, modalTitle} = this.state;
@@ -114,7 +114,7 @@ class MasterWindow extends Component {
                 docNoData = {docNoData}
                 docSummaryData = {docSummaryData}
                 dataId={dataId}
-                windowType={type}
+                windowType={params.windowType}
                 breadcrumb={breadcrumb}
                 references={references}
                 actions={actions}


### PR DESCRIPTION
windowType={windowType ? parseInt(windowType) : ''} is for additional secure if somehow windowType will be NaN and cause infinite loop. And 'type' was changed because was undefined