### PR TITLE
#971 Page Up and Page Down load all data even if there is only one page

### DIFF
--- a/src/components/shortcuts/PaginationContextShortcuts.js
+++ b/src/components/shortcuts/PaginationContextShortcuts.js
@@ -8,7 +8,7 @@ class PaginationContextShortcuts extends Component {
 
     handleShortcuts = (action, event) => {
         const {
-            handleFirstPage, handleLastPage, handlePrevPage, handleNextPage
+            handleFirstPage, handleLastPage, handlePrevPage, handleNextPage, pages
         } = this.props;
 
         switch (action) {
@@ -20,10 +20,14 @@ class PaginationContextShortcuts extends Component {
                 return handleLastPage();
             case 'NEXT_PAGE':
                 event.preventDefault();
-                return handleNextPage();
+                if (pages > 1)
+                    return handleNextPage();
+                return;
             case 'PREV_PAGE':
                 event.preventDefault();
-                return handlePrevPage();
+                if (pages > 1)
+                    return handlePrevPage();
+                return;
         }
     }
 

--- a/src/components/table/TablePagination.js
+++ b/src/components/table/TablePagination.js
@@ -317,6 +317,7 @@ class TablePagination extends Component {
                         }
                         handleNextPage={() => handleChangePage('up')}
                         handlePrevPage={() => handleChangePage('down')}
+                        pages={pages}
                     />
                 }
             </div>


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh-webui-frontend/issues/971
So I've simply made handleNextPage() or handlePrevPage() is not called when pages number is not greater than 1.

Steps to test
Go to any window with few lines (one page) then start pressing PgUp and PgDn
On each key pressing the data is not reloaded