### PR TITLE
#979 Use the Provided Endpoint w/ entry selections for given Breadcrumb 

### DIFF
--- a/src/actions/MenuActions.js
+++ b/src/actions/MenuActions.js
@@ -88,7 +88,7 @@ export function getWindowBreadcrumb(id){
                 for(let i = 0; i < pathData.length; i++){
                     const node = pathData[i];
 
-                    breadcrumbRequest(node.nodeId, 10).then(item => {
+                    breadcrumbRequest(node.nodeId).then(item => {
                         node.children = item.data;
                         req += 1;
 

--- a/src/actions/MenuActions.js
+++ b/src/actions/MenuActions.js
@@ -47,6 +47,12 @@ export function rootRequest(limit, depth = 0, onlyFavorites) {
         (onlyFavorites ? '&favorites=true' : '')
     );
 }
+export function breadcrumbRequest(nodeId) {
+    return axios.get(
+        config.API_URL +
+        '/menu/node/' + nodeId + '/breadcrumbMenu'
+    );
+}
 
 // END OF REQUESTS
 
@@ -82,7 +88,7 @@ export function getWindowBreadcrumb(id){
                 for(let i = 0; i < pathData.length; i++){
                     const node = pathData[i];
 
-                    nodePathsRequest(node.nodeId, 10).then(item => {
+                    breadcrumbRequest(node.nodeId, 10).then(item => {
                         node.children = item.data;
                         req += 1;
 

--- a/src/components/header/Breadcrumb.js
+++ b/src/components/header/Breadcrumb.js
@@ -60,7 +60,7 @@ class Breadcrumb extends Component {
             handleMenuOverlay, windowType
         } = this.props;
 
-        if(menu && menu.children && menu.children.elementId) {
+        if(menu && menu.elementId) {
             (windowType) && this.linkToPage(windowType);
         } else {
             handleMenuOverlay(e, menu.nodeId);
@@ -96,7 +96,7 @@ class Breadcrumb extends Component {
                 >
                     <span className="header-item icon-sm">
                         {index ?
-                            menu.children.captionBreadcrumb :
+                            menu.caption :
                             <i className="meta-icon-menu" />
                         }
                     </span>

--- a/src/components/header/MenuOverlay.js
+++ b/src/components/header/MenuOverlay.js
@@ -12,7 +12,8 @@ import {
     pathRequest,
     getWindowBreadcrumb,
     flattenLastElem,
-    getRootBreadcrumb
+    getRootBreadcrumb,
+    breadcrumbRequest
 } from '../../actions/MenuActions';
 
 class MenuOverlay extends Component {
@@ -28,11 +29,25 @@ class MenuOverlay extends Component {
     }
 
     componentDidMount = () => {
-        getRootBreadcrumb().then(response => {
-            this.setState({
-                data: response
+
+
+        const {
+            nodeId
+        } = this.props;
+        if(nodeId == 0){
+            getRootBreadcrumb().then(response => {
+                this.setState({
+                    data: response
+                })
             })
-        })
+        }else {
+            breadcrumbRequest(nodeId).then(response => {
+                this.setState({
+                    data: response.data
+                })
+            })
+        }
+
     }
 
     handleClickOutside = (e) => this.props.onClickOutside(e);
@@ -193,7 +208,7 @@ class MenuOverlay extends Component {
                     handleMenuOverlay={handleMenuOverlay}
                     openModal={openModal}
                     subNavigation={true}
-                    children={nodeData.children.filter(item => !item.children)}
+                    children={nodeData}
                     type={nodeData.type}
                 />
             </div>
@@ -385,7 +400,8 @@ class MenuOverlay extends Component {
         const {
             nodeId, node, handleMenuOverlay, openModal
         } = this.props;
-        const nodeData = nodeId == '0' ? data : node.children;
+        const nodeData = data.length ? data : (node && node.children ? node.children : node );
+
         return (
             <div
                 className="menu-overlay menu-overlay-primary"

--- a/src/components/header/MenuOverlayContainer.js
+++ b/src/components/header/MenuOverlayContainer.js
@@ -24,7 +24,6 @@ class MenuOverlayContainer extends Component {
             back, handleMenuOverlay, openModal, showBookmarks, updateData,
             transparentBookmarks, onKeyDown
         } = this.props;
-
         return (
             <div
                 tabIndex={0}
@@ -55,7 +54,7 @@ class MenuOverlayContainer extends Component {
                     />
                 }
 
-                {children && children.map((subitem, subindex) =>
+                {children && (children.length > 0) && children.map((subitem, subindex) =>
                     subitem.children && printChildren ?
                         <MenuOverlayContainer
                             key={subindex}


### PR DESCRIPTION
https://github.com/metasfresh/metasfresh-webui-frontend/issues/979
I've refactored Breadcrumb component using `GET /rest/api/menu/node/{nodeId}/breadcrumbMenu` Endpoint.

Steps to test
-Check breadcrumb while clicking on nodes in menu
-It provide only selected level node, not full tree