### PR TITLE
fix(Filter): keep track of active filters

### DIFF
--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -55,7 +55,7 @@ class DocumentList extends Component {
             viewId: defaultViewId,
             page: defaultPage || 1,
             sort: defaultSort,
-            filters: null,
+            filters: [],
 
             clickOutsideLock: false,
             refresh: null,
@@ -434,13 +434,40 @@ class DocumentList extends Component {
         });
     }
 
-    handleFilterChange = (filters) => {
-        this.setState({
-            filters: filters,
-            page: 1
-        }, () => {
-            this.fetchLayoutAndData(true);
-        })
+    uniqueFilters = (array, key) => {
+        const keys = array.map(k => k[key]);
+        const uniqObject = keys.reduce((curr, next) => {
+            if (!curr[next])
+                curr[next] = true;
+            return curr;
+        }, {});
+        const uniqKeys = Object.keys(uniqObject);
+
+        return uniqKeys.map((k) => {
+            return array.filter(i => i[key] === k)[0];
+        });
+    }
+
+    handleFilterChange = (filter, add = true) => {
+        if (add) {
+            this.setState({
+                filters: this.uniqueFilters([
+                    filter, ...this.state.filters
+                ], 'filterId'),
+                page: 1
+            }, () => {
+                this.fetchLayoutAndData(true);
+            });
+        } else {
+            this.setState({
+                filters: this.state.filters.filter(item => {
+                    return item.filterId !== filter.filterId;
+                }),
+                page: 1
+            }, () => {
+                this.fetchLayoutAndData(true);
+            });
+        }
     }
 
     // END OF MANAGING SORT, PAGINATION, FILTERS -------------------------------

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -55,7 +55,7 @@ class DocumentList extends Component {
             viewId: defaultViewId,
             page: defaultPage || 1,
             sort: defaultSort,
-            filters: [],
+            filters: null,
 
             clickOutsideLock: false,
             refresh: null,
@@ -449,10 +449,11 @@ class DocumentList extends Component {
     }
 
     handleFilterChange = (filter, add = true) => {
+        const stateFilter = this.state.filters || [];
         if (add) {
             this.setState({
                 filters: this.uniqueFilters([
-                    filter, ...this.state.filters
+                    filter, ...stateFilter
                 ], 'filterId'),
                 page: 1
             }, () => {
@@ -460,7 +461,7 @@ class DocumentList extends Component {
             });
         } else {
             this.setState({
-                filters: this.state.filters.filter(item => {
+                filters: stateFilter.filter(item => {
                     return item.filterId !== filter.filterId;
                 }),
                 page: 1

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -49,19 +49,19 @@ class Filters extends Component {
                     Object.assign({}, filter, {
                         parameters: this.parseToPatch(filter.parameters)
                     }) : filter;
-                this.setFilterActive([parsedFilter]);
+                this.setFilterActive(parsedFilter);
                 cb && cb();
             }
         });
     }
 
-    setFilterActive = (filter) => {
+    setFilterActive = (filter, add = true) => {
         const {updateDocList} = this.props;
 
         this.setState({
             filter: filter
         }, () => {
-            updateDocList(filter);
+            updateDocList(filter, add);
         })
     }
 
@@ -76,7 +76,7 @@ class Filters extends Component {
     }
 
     clearFilters = () => {
-        this.setFilterActive(null)
+        this.setFilterActive(this.state.filter, false);
     }
 
     dropdownToggled = () => {


### PR DESCRIPTION
Problem: filters stored as objects, they override each other every time 1 filter changes
Solution: Keep track of every filter separate, using single uniq key identifier

task: https://github.com/metasfresh/metasfresh-webui-frontend/issues/1021