### PR TITLE
#1031 Autoselect when doubleclick on included Tab Row Field

### DIFF
--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -41,7 +41,7 @@ class TableItem extends Component {
                             .getElementsByClassName('js-input-field')[0];
 
                     if(elem){
-                        elem.focus();
+                        elem.select();
                     }
 
                     const disabled =


### PR DESCRIPTION
changing focus() method to select() method
Fix #1031 