### PR TITLE
Incorrect handling of blur event when dropdown control is readonly #1161

### DIFF
--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -365,7 +365,7 @@ class RawList extends Component {
     }
 
     handleKeyDown = (e) => {
-        const { onSelect, list } = this.props;
+        const { onSelect, list, readonly } = this.props;
         const { selected, isOpen } = this.state;
 
         if ((e.keyCode > 47) && (e.keyCode < 123)) {
@@ -402,7 +402,7 @@ class RawList extends Component {
                     break;
 
                 case 'Tab':
-                    (list.length === 0) && onSelect(null);
+                    ((list.length === 0) && !readonly) && onSelect(null);
                     break;
             }
         }


### PR DESCRIPTION
belongs to https://github.com/metasfresh/metasfresh-webui-frontend/issues/1161