### PR TITLE
Use defaultOrderBys from tabs layout #1147

### DIFF
--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -60,7 +60,7 @@ class Window extends Component {
                     const {
                         tabid, caption, elements, emptyResultText,
                         emptyResultHint, queryOnActivate, supportQuickInput,
-                        orderBy
+                        defaultOrderBys
                     } = elem;
                     return (
                         <Table
@@ -73,7 +73,7 @@ class Window extends Component {
                             tabid={tabid}
                             type={type}
                             sort={sort}
-                            orderBy={orderBy}
+                            orderBy={defaultOrderBys}
                             docId={dataId}
                             emptyText={emptyResultText}
                             emptyHint={emptyResultHint}


### PR DESCRIPTION
Use defaultOrderBys from tabs layout to configure default ordering in tabbed grid