### PR TITLE
HOTFIX: Remove default value of docId

### DIFF
--- a/src/actions/GenericActions.js
+++ b/src/actions/GenericActions.js
@@ -49,7 +49,10 @@ export function createInstance(entity, docType, docId, tabId, subentity) {
 }
 
 export function patchRequest({
-    docId = 'NEW',
+    // HOTFIX: before refactoring all calls explicity set docId to `null`
+    // instead of `undefined` so default value 'NEW' was never used!
+    docId,
+
     docType,
     entity,
     isAdvanced,


### PR DESCRIPTION
(See #1234)

Looks like an old code smell revealed: Default values in JS are only applied, if the argument is omitted or `undefined` is passed explicitly.

(Introduced by b4cb8eca1360b903c53df1168734e37b5ebac46a)