### PR TITLE
Show includedView DocumentList in non-modal DocList

### DIFF
--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -29,6 +29,7 @@ import {
 } from '../../actions/WindowActions';
 
 import {
+    closeListIncludedView,
     setSorting,
     setPagination,
     setListId,
@@ -504,13 +505,19 @@ class DocumentList extends Component {
         } = this.props;
 
         this.setState({
-            isShowIncluded: showIncludedView ? true : false,
-            hasShowIncluded: showIncludedView ? true : false
+            isShowIncluded: !!showIncludedView,
+            hasShowIncluded: !!showIncludedView,
         }, ()=> {
             if (showIncludedView) {
                 dispatch(setListIncludedView(data.windowId, data.viewId));
             }
         });
+
+        // can't use setState callback because component might be unmounted and
+        // callback is never called
+        if (!showIncludedView) {
+            dispatch(closeListIncludedView());
+        }
     }
 
     render() {

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -72,6 +72,7 @@ class Table extends Component {
             dispatch, mainTable, open, rowData, defaultSelected,
             disconnectFromState, type, refreshSelection,
             supportIncludedViewOnSelect, viewId, isModal, hasIncluded,
+            showIncludedViewOnSelect
         } = this.props;
 
         const {
@@ -127,7 +128,17 @@ class Table extends Component {
             this.setState({
                 selected: []
             });
+
+            this.deselectAllProducts();
+            showIncludedViewOnSelect && showIncludedViewOnSelect(false);
         }
+    }
+
+    componentWillUnmount() {
+        const { showIncludedViewOnSelect } = this.props;
+
+        this.deselectAllProducts();
+        showIncludedViewOnSelect && showIncludedViewOnSelect(false);
     }
 
     showSelectedIncludedView = (selected) => {

--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -101,28 +101,48 @@ class DocList extends Component {
                 modalDescription={modalDescription}
                 showIndicator={!modal.visible && !rawModal.visible}
             >
-                 <DocumentList
-                     type="grid"
-                     updateUri={this.updateUriCallback}
-                     windowType={windowType}
-                     defaultViewId={query.viewId}
-                     defaultSort={query.sort}
-                     defaultPage={parseInt(query.page)}
-                     refType={query.refType}
-                     refId={query.refId}
-                     refTabId={query.refTabId}
-                     refRowIds={refRowIds}
-                     selectedWindowType={selectedWindowType}
-                     selected={selected}
-                     inBackground={rawModal.visible}
-                     inModal={modal.visible}
-                     fetchQuickActionsOnInit={true}
-                     processStatus={processStatus}
-                     disablePaginationShortcuts=
-                        {modal.visible || rawModal.visible}
-                    setNotFound={this.setNotFound}
-                    notfound={notfound}
-                 />
+                <div className="document-lists-wrapper">
+                    <DocumentList
+                        type="grid"
+                        updateUri={this.updateUriCallback}
+                        windowType={windowType}
+                        defaultViewId={query.viewId}
+                        defaultSort={query.sort}
+                        defaultPage={parseInt(query.page)}
+                        refType={query.refType}
+                        refId={query.refId}
+                        refTabId={query.refTabId}
+                        refRowIds={refRowIds}
+                        selectedWindowType={selectedWindowType}
+                        selected={selected}
+                        includedView={includedView}
+                        inBackground={rawModal.visible}
+                        inModal={modal.visible}
+                        fetchQuickActionsOnInit={true}
+                        processStatus={processStatus}
+                        disablePaginationShortcuts={
+                            modal.visible || rawModal.visible
+                        }
+                        setNotFound={this.setNotFound}
+                        notfound={notfound}
+                    />
+
+                    {(includedView && includedView.windowType &&
+                        includedView.viewId
+                    ) && (
+                        <DocumentList
+                            type="includedView"
+                            selected={selected}
+                            selectedWindowType={selectedWindowType}
+                            windowType={includedView.windowType}
+                            defaultViewId={includedView.viewId}
+                            fetchQuickActionsOnInit={true}
+                            processStatus={processStatus}
+                            inBackground={rawModal.visible}
+                            inModal={modal.visible}
+                        />
+                    )}
+                </div>
             </Container>
         );
     }


### PR DESCRIPTION
(See #1239)

Basically the same code for `includedView` as in `components/Container.js`:
https://github.com/metasfresh/metasfresh-webui-frontend/blob/d9327306cc515c45fea948e230a70ac7198019f7/src/components/Container.js#L92-L129

Additionally hiding `includedView` when unmounting or changing `viewId` of `Table`