### PR TITLE
Hotfix includedView not showing in modals

### DIFF
--- a/src/actions/ListActions.js
+++ b/src/actions/ListActions.js
@@ -50,8 +50,10 @@ export function setListIncludedView(windowType, viewId) {
     }
 }
 
-export function closeListIncludedView() {
+export function closeListIncludedView(windowType, viewId) {
     return {
-        type: types.CLOSE_LIST_INCLUDED_VIEW
-    }
+        type: types.CLOSE_LIST_INCLUDED_VIEW,
+        windowType,
+        viewId,
+    };
 }

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -500,23 +500,28 @@ class DocumentList extends Component {
     }
 
     showIncludedViewOnSelect = (showIncludedView, data) => {
-        const {
-            dispatch
-        } = this.props;
+        const { dispatch } = this.props;
 
         this.setState({
             isShowIncluded: !!showIncludedView,
             hasShowIncluded: !!showIncludedView,
-        }, ()=> {
+        }, () => {
             if (showIncludedView) {
-                dispatch(setListIncludedView(data.windowId, data.viewId));
+                dispatch(setListIncludedView(
+                    // some events pass windowId, some pass windowType
+                    data.windowId || data.windowType,
+                    data.viewId,
+                ));
             }
         });
 
         // can't use setState callback because component might be unmounted and
         // callback is never called
         if (!showIncludedView) {
-            dispatch(closeListIncludedView());
+            dispatch(closeListIncludedView(
+                data.windowId || data.windowType,
+                data.viewId,
+            ));
         }
     }
 
@@ -665,7 +670,7 @@ class DocumentList extends Component {
                                 {...{isIncluded, disconnectFromState, autofocus,
                                     open, page, closeOverlays, inBackground,
                                     disablePaginationShortcuts, isModal,
-                                    hasIncluded, viewId
+                                    hasIncluded, viewId, windowType,
                                 }}
                             >
                                 {layout.supportAttributes && !isIncluded &&

--- a/src/components/app/RawModal.js
+++ b/src/components/app/RawModal.js
@@ -92,11 +92,11 @@ class RawModal extends Component {
     }
 
     removeModal = () => {
-        const {dispatch, modalVisible} = this.props;
+        const { dispatch, modalVisible, windowType, viewId } = this.props;
 
         dispatch(closeRawModal());
         dispatch(closeModal());
-        dispatch(closeListIncludedView());
+        dispatch(closeListIncludedView(windowType, viewId));
 
         if (!modalVisible){
             document.body.style.overflow = 'auto';

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -130,15 +130,20 @@ class Table extends Component {
             });
 
             this.deselectAllProducts();
-            showIncludedViewOnSelect && showIncludedViewOnSelect(false);
+            showIncludedViewOnSelect && showIncludedViewOnSelect(false, {
+                windowType: prevProps.windowType,
+                viewId: prevProps.viewid,
+            });
         }
     }
 
     componentWillUnmount() {
-        const { showIncludedViewOnSelect } = this.props;
+        const { showIncludedViewOnSelect, viewId, windowType } = this.props;
 
         this.deselectAllProducts();
-        showIncludedViewOnSelect && showIncludedViewOnSelect(false);
+        if (showIncludedViewOnSelect) {
+            showIncludedViewOnSelect(false, { windowType, viewId });
+        }
     }
 
     showSelectedIncludedView = (selected) => {
@@ -351,7 +356,7 @@ class Table extends Component {
     }
 
     handleClickOutside = (event) => {
-        const { showIncludedViewOnSelect } = this.props;
+        const { showIncludedViewOnSelect, viewId, windowType } = this.props;
         if(
             event.target.parentNode !== document &&
             (event.target.parentNode &&
@@ -370,7 +375,9 @@ class Table extends Component {
             }
 
             this.deselectAllProducts();
-            showIncludedViewOnSelect && showIncludedViewOnSelect(false);
+            if (showIncludedViewOnSelect) {
+                showIncludedViewOnSelect(false, { windowType, viewId });
+            }
         }
     }
 

--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -128,7 +128,8 @@ class DocList extends Component {
                     />
 
                     {(includedView && includedView.windowType &&
-                        includedView.viewId
+                        includedView.viewId && !rawModal.visible &&
+                        !modal.visible
                     ) && (
                         <DocumentList
                             type="includedView"
@@ -138,8 +139,8 @@ class DocList extends Component {
                             defaultViewId={includedView.viewId}
                             fetchQuickActionsOnInit={true}
                             processStatus={processStatus}
-                            inBackground={rawModal.visible}
-                            inModal={modal.visible}
+                            inBackground={false}
+                            inModal={false}
                         />
                     )}
                 </div>

--- a/src/reducers/listHandler.js
+++ b/src/reducers/listHandler.js
@@ -60,12 +60,19 @@ export default function listHandler(state = initialState, action) {
             });
 
         case types.CLOSE_LIST_INCLUDED_VIEW:
-            return Object.assign({}, state, {
-                includedView: Object.assign({}, state.includedView, {
-                    viewId: '',
-                    windowType: null
-                })
-            });
+            if ((state.includedView.windowType === action.windowType) &&
+                (state.includedView.viewId === action.viewId)
+            ) {
+                // only close includedView if it hasn't changed since
+                return Object.assign({}, state, {
+                    includedView: Object.assign({}, state.includedView, {
+                        viewId: '',
+                        windowType: null
+                    })
+                });
+            } else {
+                return state;
+            }
 
         default:
             return state;


### PR DESCRIPTION
(See #1243)

There are two bigger issues involved in this:
* Inconsistency with `windowId` and `windowType`. Is it correct, that only `windowType` should be used? Or are these two different things?
* There only is one global `includedView`, that's why it was not shown. There should be an `includedView` per `DocumentList`