### PR TITLE
Hide DataLayoutWrapper in included non-modal DocList

### DIFF
--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -139,6 +139,7 @@ class DocList extends Component {
                             defaultViewId={includedView.viewId}
                             fetchQuickActionsOnInit={true}
                             processStatus={processStatus}
+                            isIncluded={true}
                             inBackground={false}
                             inModal={false}
                         />


### PR DESCRIPTION
(See #1239 and https://github.com/metasfresh/metasfresh-webui-frontend/issues/1239#issuecomment-335091640)

Mark `DocumentList` of `includedView` as `isIncluded` to hide selection attributes