### PR TITLE
Implement selections per windowType and viewId

### DIFF
--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -261,12 +261,11 @@ export function indicatorState(state) {
 
 //SELECT ON TABLE
 
-export function selectTableItems(ids, windowType) {
+export function selectTableItems({ ids, windowType, viewId }) {
     return {
         type: types.SELECT_TABLE_ITEMS,
-        ids,
-        windowType
-    }
+        payload: { ids, windowType, viewId },
+    };
 }
 
 // THUNK ACTIONS

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -23,9 +23,9 @@ class Container extends Component {
             showSidelist, siteName, connectionError, noMargin, entity, children,
             query, attachments, showIndicator, isDocumentNotSaved, hideHeader,
             handleDeletedStatus, dropzoneFocused, notfound, rawModal, modal,
-            selected, selectedWindowType, indicator, modalTitle, setModalTitle,
-            includedView, closeModalCallback, setModalDescription,
-            modalDescription, editmode, handleEditModeToggle, activeTab
+            indicator, modalTitle, setModalTitle, includedView,
+            closeModalCallback, setModalDescription, modalDescription, editmode,
+            handleEditModeToggle, activeTab,
         } = this.props;
 
         return (
@@ -87,7 +87,6 @@ class Container extends Component {
                             relativeDataId={dataId}
                             triggerField={modal.triggerField}
                             query={query}
-                            selected={selected}
                             viewId={query && query.viewId}
                             rawModalVisible={rawModal.visible}
                             indicator={indicator}
@@ -118,8 +117,6 @@ class Container extends Component {
                                     type="grid"
                                     windowType={rawModal.type}
                                     defaultViewId={rawModal.viewId}
-                                    selected={selected}
-                                    selectedWindowType={selectedWindowType}
                                     setModalTitle={setModalTitle}
                                     setModalDescription={setModalDescription}
                                     fetchQuickActionsOnInit={!(
@@ -142,8 +139,6 @@ class Container extends Component {
                                 ) && (
                                     <DocumentList
                                         type="includedView"
-                                        selected={selected}
-                                        selectedWindowType={selectedWindowType}
                                         windowType={includedView.windowType}
                                         defaultViewId={includedView.viewId}
                                         fetchQuickActionsOnInit

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -7,9 +7,13 @@ import Modal from './app/Modal';
 import RawModal from './app/RawModal';
 import DocumentList from './app/DocumentList';
 
+const mapStateToProps = state => ({
+    connectionError: state.windowHandler.connectionError || false,
+});
+
 class Container extends Component {
-    constructor(props){
-        super(props);
+    static propTypes = {
+        connectionError: PropTypes.bool,
     }
 
     render() {
@@ -26,109 +30,133 @@ class Container extends Component {
 
         return (
             <div>
-                {
+                {!hideHeader && (
                     // Forcing refresh component
-                    !hideHeader && <Header
-                        {...{entity, docStatusData, docNoData, docSummaryData,
-                            handleDeletedStatus, isDocumentNotSaved,
-                            showIndicator, query, siteName, showSidelist,
-                            attachments, actions, references, windowType,
-                            breadcrumb, dataId, dropzoneFocused, notfound,
-                            docId, editmode, handleEditModeToggle, activeTab
-                        }}
-                        docStatus = {docActionElem}
+                    <Header
+                        entity={entity}
+                        docStatusData={docStatusData}
+                        docNoData={docNoData}
+                        docSummaryData={docSummaryData}
+                        handleDeletedStatus={handleDeletedStatus}
+                        isDocumentNotSaved={isDocumentNotSaved}
+                        showIndicator={showIndicator}
+                        query={query}
+                        siteName={siteName}
+                        showSidelist={showSidelist}
+                        attachments={attachments}
+                        actions={actions}
+                        references={references}
+                        windowType={windowType}
+                        breadcrumb={breadcrumb}
+                        dataId={dataId}
+                        dropzoneFocused={dropzoneFocused}
+                        notfound={notfound}
+                        docId={docId}
+                        editmode={editmode}
+                        handleEditModeToggle={handleEditModeToggle}
+                        activeTab={activeTab}
+                        docStatus={docActionElem}
                     />
-                }
-                {connectionError && <ErrorScreen />}
+                )}
+
+                {connectionError && (
+                    <ErrorScreen />
+                )}
+
                 <div
                     className={
                         'header-sticky-distance js-unselect ' +
                         (noMargin ? 'dashboard' : 'container-fluid')
                     }
                 >
-                {modal.visible &&
-                    <Modal
-                        windowType={modal.type}
-                        dataId={modal.dataId ? modal.dataId : dataId}
-                        data={modal.data}
-                        layout={modal.layout}
-                        rowData={modal.rowData}
-                        tabId={modal.tabId}
-                        rowId={modal.rowId}
-                        modalTitle={modal.title}
-                        modalType={modal.modalType}
-                        modalViewId={modal.viewId}
-                        isAdvanced={modal.isAdvanced}
-                        relativeType={windowType}
-                        relativeDataId={dataId}
-                        triggerField={modal.triggerField}
-                        query={query}
-                        selected={selected}
-                        viewId={query && query.viewId}
-                        rawModalVisible={rawModal.visible}
-                        indicator={indicator}
-                        modalViewDocumentIds={modal.viewDocumentIds}
-                        closeCallback={closeModalCallback}
-                        modalSaveStatus={
-                            modal.saveStatus &&
-                            modal.saveStatus.saved !== undefined ?
-                                modal.saveStatus.saved : true
-                        }
-                        isDocumentNotSaved={
-                            (modal.saveStatus && !modal.saveStatus.saved) &&
-                            (modal.validStatus &&
-                                !modal.validStatus.initialValue)
-                        }
-                     />
-                 }
 
-                 {rawModal.visible && (
-                     <RawModal
-                         modalTitle={modalTitle}
-                         modalDescription={modalDescription}
-                         windowType={rawModal.type}
-                         viewId={rawModal.viewId}
-                     >
-                        <div className="document-lists-wrapper">
-                             <DocumentList
-                                 type="grid"
-                                 windowType={rawModal.type}
-                                 defaultViewId={rawModal.viewId}
-                                 selected={selected}
-                                 selectedWindowType={selectedWindowType}
-                                 setModalTitle={setModalTitle}
-                                 setModalDescription={setModalDescription}
-                                 fetchQuickActionsOnInit={!(includedView.windowType && includedView.viewId)}
-                                 modalDescription={this.modalDescription}
-                                 isModal={true}
-                                 processStatus={processStatus}
-                                 includedView={includedView}
-                                 inBackground={
-                                     includedView.windowType &&
+                    {modal.visible && (
+                        <Modal
+                            windowType={modal.type}
+                            dataId={modal.dataId ? modal.dataId : dataId}
+                            data={modal.data}
+                            layout={modal.layout}
+                            rowData={modal.rowData}
+                            tabId={modal.tabId}
+                            rowId={modal.rowId}
+                            modalTitle={modal.title}
+                            modalType={modal.modalType}
+                            modalViewId={modal.viewId}
+                            isAdvanced={modal.isAdvanced}
+                            relativeType={windowType}
+                            relativeDataId={dataId}
+                            triggerField={modal.triggerField}
+                            query={query}
+                            selected={selected}
+                            viewId={query && query.viewId}
+                            rawModalVisible={rawModal.visible}
+                            indicator={indicator}
+                            modalViewDocumentIds={modal.viewDocumentIds}
+                            closeCallback={closeModalCallback}
+                            modalSaveStatus={
+                                modal.saveStatus &&
+                                modal.saveStatus.saved !== undefined ?
+                                    modal.saveStatus.saved : true
+                            }
+                            isDocumentNotSaved={
+                                (modal.saveStatus && !modal.saveStatus.saved) &&
+                                (modal.validStatus &&
+                                    !modal.validStatus.initialValue)
+                            }
+                        />
+                    )}
+
+                    {rawModal.visible && (
+                        <RawModal
+                            modalTitle={modalTitle}
+                            modalDescription={modalDescription}
+                            windowType={rawModal.type}
+                            viewId={rawModal.viewId}
+                        >
+                            <div className="document-lists-wrapper">
+                                <DocumentList
+                                    type="grid"
+                                    windowType={rawModal.type}
+                                    defaultViewId={rawModal.viewId}
+                                    selected={selected}
+                                    selectedWindowType={selectedWindowType}
+                                    setModalTitle={setModalTitle}
+                                    setModalDescription={setModalDescription}
+                                    fetchQuickActionsOnInit={!(
+                                        includedView.windowType &&
                                         includedView.viewId
-                                 }
-                                 inModal={modal.visible}
-                             >
-                             </DocumentList>
+                                    )}
+                                    modalDescription={this.modalDescription}
+                                    isModal
+                                    processStatus={processStatus}
+                                    includedView={includedView}
+                                    inBackground={
+                                        includedView.windowType &&
+                                           includedView.viewId
+                                    }
+                                    inModal={modal.visible}
+                                />
 
-                             {(includedView && includedView.windowType && includedView.viewId) && (
-                                 <DocumentList
-                                     type="includedView"
-                                     selected={selected}
-                                     selectedWindowType={selectedWindowType}
-                                     windowType={includedView.windowType}
-                                     defaultViewId={includedView.viewId}
-                                     fetchQuickActionsOnInit={true}
-                                     isModal={true}
-                                     isIncluded={true}
-                                     processStatus={processStatus}
-                                     inBackground={false}
-                                     inModal={modal.visible}
-                                 />
-                             )}
-                        </div>
-                     </RawModal>
-                 )}
+                                {(includedView && includedView.windowType &&
+                                    includedView.viewId
+                                ) && (
+                                    <DocumentList
+                                        type="includedView"
+                                        selected={selected}
+                                        selectedWindowType={selectedWindowType}
+                                        windowType={includedView.windowType}
+                                        defaultViewId={includedView.viewId}
+                                        fetchQuickActionsOnInit
+                                        isModal
+                                        isIncluded
+                                        processStatus={processStatus}
+                                        inBackground={false}
+                                        inModal={modal.visible}
+                                    />
+                                )}
+                            </div>
+                        </RawModal>
+                    )}
 
                     {children}
                 </div>
@@ -136,13 +164,5 @@ class Container extends Component {
         );
     }
 }
-
-Container.propTypes = {
-    connectionError: PropTypes.bool
-};
-
-const mapStateToProps = state => ({
-    connectionError: state.windowHandler.connectionError || false
-});
 
 export default connect(mapStateToProps)(Container);

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -115,13 +115,17 @@ class DocumentList extends Component {
             (refId !== this.props.refId)
         ) {
             this.setState({
-                data:null,
-                layout:null,
+                data: null,
+                layout: null,
                 filters: null,
-                viewId: null
+                viewId: null,
             }, () => {
                 if (!disconnectFromState) {
-                    dispatch(selectTableItems([], null));
+                    dispatch(selectTableItems({
+                        windowType,
+                        viewId,
+                        ids: [],
+                    }));
                 }
 
                 this.fetchLayoutAndData();
@@ -167,19 +171,14 @@ class DocumentList extends Component {
         ) {
             if (!inBackground) {
                 // In case of preventing cached selection restore
-                if (
-                    !disconnectFromState &&
-                    this.cachedSelection
-                ) {
-                    dispatch(
-                        selectTableItems(
-                            this.cachedSelection,
-                            this.props.windowType
-                        )
-                    );
+                if (!disconnectFromState && this.cachedSelection) {
+                    dispatch(selectTableItems({
+                        windowType,
+                        viewId,
+                        ids: this.cachedSelection,
+                    }));
                 }
-            }
-            else {
+            } else {
                 this.cachedSelection = selected;
             }
         }
@@ -374,6 +373,7 @@ class DocumentList extends Component {
         const {
             dispatch, windowType, updateUri, setNotFound, type, isIncluded
         } = this.props;
+        const { viewId } = this.state;
 
         setNotFound && setNotFound(false);
         dispatch(indicatorState('pending'));
@@ -413,9 +413,11 @@ class DocumentList extends Component {
 
                         this.cachedSelection = null;
 
-                        dispatch(
-                            selectTableItems(selection, windowType)
-                        );
+                        dispatch(selectTableItems({
+                            windowType,
+                            viewId,
+                            ids: selection,
+                        }));
                     }
 
                     this.connectWS(response.data.viewId);

--- a/src/components/app/Modal.js
+++ b/src/components/app/Modal.js
@@ -13,6 +13,7 @@ import {
     handleProcessResponse,
     patch,
 } from '../../actions/WindowActions';
+import { getSelection } from '../../reducers/windowHandler';
 import keymap from '../../keymap.js';
 
 import Process from '../Process';
@@ -24,6 +25,14 @@ import Indicator from './Indicator';
 import OverlayField from './OverlayField';
 
 const shortcutManager = new ShortcutManager(keymap);
+
+const mapStateToProps = (state, props) => ({
+    selected: getSelection({
+        state,
+        windowType: props.windowType,
+        viewId: props.viewId,
+    }),
+});
 
 class Modal extends Component {
     mounted = false;
@@ -495,4 +504,4 @@ class Modal extends Component {
     }
 }
 
-export default connect()(Modal);
+export default connect(mapStateToProps)(Modal);

--- a/src/components/app/Modal.js
+++ b/src/components/app/Modal.js
@@ -1,40 +1,45 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 import counterpart from 'counterpart';
-
-import Window from '../Window';
-import Process from '../Process';
-import Indicator from './Indicator';
-import OverlayField from './OverlayField';
-import keymap from '../../keymap.js';
-import ModalContextShortcuts from '../shortcuts/ModalContextShortcuts';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import {connect} from 'react-redux';
 import { ShortcutManager } from 'react-shortcuts';
-import Tooltips from '../tooltips/Tooltips.js'
-const shortcutManager = new ShortcutManager(keymap);
 
+import { processNewRecord } from '../../actions/GenericActions';
 import {
     closeModal,
     createWindow,
     createProcess,
     startProcess,
     handleProcessResponse,
-    patch
+    patch,
 } from '../../actions/WindowActions';
+import keymap from '../../keymap.js';
 
-import {
-    processNewRecord
-} from '../../actions/GenericActions';
+import Process from '../Process';
+import ModalContextShortcuts from '../shortcuts/ModalContextShortcuts';
+import Tooltips from '../tooltips/Tooltips.js'
+import Window from '../Window';
+
+import Indicator from './Indicator';
+import OverlayField from './OverlayField';
+
+const shortcutManager = new ShortcutManager(keymap);
 
 class Modal extends Component {
     mounted = false;
 
+    static childContextTypes = {
+        shortcuts: PropTypes.object.isRequired,
+    }
+
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+    }
+
     constructor(props) {
         super(props);
 
-        const {
-            rowId, dataId
-        } = this.props;
+        const { rowId, dataId } = props;
 
         this.state = {
             scrolled: false,
@@ -43,8 +48,8 @@ class Modal extends Component {
             init: false,
             pending: false,
             waitingFetch: false,
-            isTooltipShow: false
-        }
+            isTooltipShow: false,
+        };
     }
 
     async componentDidMount() {
@@ -73,11 +78,8 @@ class Modal extends Component {
     }
 
     async componentDidUpdate (prevProps) {
-        const {
-            windowType, indicator
-        } = this.props;
-
-        const {waitingFetch} = this.state;
+        const { windowType, indicator } = this.props;
+        const { waitingFetch } = this.state;
 
         if (prevProps.windowType !== windowType) {
             await this.init();
@@ -85,26 +87,21 @@ class Modal extends Component {
 
         // Case when we have to trigger pending start request
         // in due to some pending patches that are required.
-        if(
-            waitingFetch &&
-            prevProps.indicator !== indicator
-        ) {
+        if (waitingFetch && prevProps.indicator !== indicator) {
             this.setState({
-                waitingFetch: false
+                waitingFetch: false,
             }, () => {
                 this.handleStart();
-            })
+            });
         }
     }
 
     toggleTooltip = (key = null) => {
-        this.setState({
-            isTooltipShow: key
-        });
+        this.setState({ isTooltipShow: key });
     }
 
     getChildContext = () => {
-        return { shortcuts: shortcutManager }
+        return { shortcuts: shortcutManager };
     }
 
     initEventListeners = () => {
@@ -126,14 +123,14 @@ class Modal extends Component {
     init = async () => {
         const {
             dispatch, windowType, dataId, tabId, rowId, modalType, selected,
-            relativeType, isAdvanced, modalViewId, modalViewDocumentIds
+            relativeType, isAdvanced, modalViewId, modalViewDocumentIds,
         } = this.props;
 
-        switch(modalType){
+        switch (modalType) {
             case 'window':
                 try {
                     await dispatch(createWindow(
-                        windowType, dataId, tabId, rowId, true, isAdvanced
+                        windowType, dataId, tabId, rowId, true, isAdvanced,
                     ));
                 } catch (error) {
                     this.handleClose();
@@ -142,6 +139,7 @@ class Modal extends Component {
                 }
 
                 break;
+
             case 'process':
                 // We have 3 cases of processes (prioritized):
                 // - with viewDocumentIds: on single page with rawModal
@@ -176,47 +174,46 @@ class Modal extends Component {
     closeModal = () => {
         const {
             dispatch, closeCallback, dataId, windowType, relativeType,
-            relativeDataId, triggerField
+            relativeDataId, triggerField,
         } = this.props;
-        const {isNew, isNewDoc} = this.state;
+        const { isNew, isNewDoc } = this.state;
 
-        if(isNewDoc) {
-            processNewRecord(
-                'window', windowType, dataId
-            ).then(response => {
+        if (isNewDoc) {
+            processNewRecord('window', windowType, dataId).then(response => {
                 dispatch(patch(
                     'window', relativeType, relativeDataId, null, null,
-                    triggerField, {[response.data]: ''}
+                    triggerField, { [response.data]: '' },
                 )).then(() => {
                     this.removeModal();
-                })
+                });
             });
-        }else{
-            closeCallback && closeCallback(isNew);
+        } else {
+            if (closeCallback) {
+                closeCallback(isNew);
+            }
+
             this.removeModal();
         }
     }
 
     removeModal = () => {
-        const {dispatch, rawModalVisible} = this.props;
+        const { dispatch, rawModalVisible } = this.props;
 
         dispatch(closeModal());
 
-        if (!rawModalVisible){
+        if (!rawModalVisible) {
             document.body.style.overflow = 'auto';
         }
     }
 
     handleClose = () => {
-        const {
-            modalSaveStatus, modalType
-        } = this.props;
+        const { modalSaveStatus, modalType } = this.props;
 
-        if(modalType === 'process') {
+        if (modalType === 'process') {
             return this.closeModal();
         }
 
-        if(modalSaveStatus || window.confirm('Do you really want to leave?')){
+        if (modalSaveStatus || window.confirm('Do you really want to leave?')) {
             this.closeModal();
         }
     }
@@ -225,30 +222,22 @@ class Modal extends Component {
         const target = event.srcElement;
         let scrollTop = target && target.body.scrollTop;
 
-        if(!scrollTop){
+        if (!scrollTop) {
             scrollTop = document.documentElement.scrollTop;
         }
 
-        this.setState({
-            scrolled: scrollTop > 0
-        });
+        this.setState({ scrolled: scrollTop > 0 });
     }
 
     setFetchOnTrue = () => {
-        this.setState({
-            waitingFetch: true
-        });
+        this.setState({ waitingFetch: true });
     }
 
     handleStart = () => {
-        const {dispatch, layout, windowType, indicator} = this.props;
+        const { dispatch, layout, windowType, indicator } = this.props;
 
-        if(indicator === 'pending'){
-            this.setState({
-                waitingFetch: true,
-                pending: true
-            });
-
+        if (indicator === 'pending') {
+            this.setState({ waitingFetch: true, pending: true });
             return;
         }
 
@@ -280,26 +269,26 @@ class Modal extends Component {
     renderModalBody = () => {
         const {
             data, layout, tabId, rowId, dataId, modalType, windowType,
-            isAdvanced
+            isAdvanced,
         } = this.props;
+        const { pending } = this.state;
 
-        const {pending} = this.state;
-
-        switch(modalType){
+        switch (modalType) {
             case 'window':
                 return (
                     <Window
                         data={data}
                         dataId={dataId}
                         layout={layout}
-                        modal={true}
+                        modal
                         tabId={tabId}
                         rowId={rowId}
-                        isModal={true}
+                        isModal
                         isAdvanced={isAdvanced}
                         tabsInfo={null}
                     />
-                )
+                );
+
             case 'process':
                 return (
                     <Process
@@ -308,137 +297,176 @@ class Modal extends Component {
                         type={windowType}
                         disabled={pending}
                     />
-                )
+                );
         }
     }
 
     renderPanel = () => {
         const {
-            data, modalTitle, modalType, isDocumentNotSaved, layout
+            data, modalTitle, modalType, isDocumentNotSaved, layout,
         } = this.props;
-
         const {
-            scrolled, pending, isNewDoc, isTooltipShow
+            scrolled, pending, isNewDoc, isTooltipShow,
         } = this.state;
 
-        return(
-            Object.keys(data).length > 0 && <div
-                className="screen-freeze js-not-unselect"
-            >
-            <div className="panel panel-modal panel-modal-primary">
-                <div
-                    className={
-                        'panel-modal-header ' +
-                        (scrolled ? 'header-shadow': '')
-                    }
-                >
-                    <span className="panel-modal-header-title">
-                        {modalTitle ? modalTitle : layout.caption}
-                    </span>
-                    <div className="items-row-2">
-                        {isNewDoc && <button
-                            className={
-                                `btn btn-meta-outline-secondary
-                                btn-distance-3 btn-md `+
-                                (pending ? 'tag-disabled disabled ' : '')
-                            }
-                            onClick={this.removeModal}
-                            tabIndex={0}
-                            onMouseEnter={() =>
-                                this.toggleTooltip(keymap.MODAL_CONTEXT.CANCEL)
-                            }
-                            onMouseLeave={this.toggleTooltip}
-                        >
-                            {counterpart.translate('modal.actions.cancel')}
-                            {isTooltipShow === keymap.MODAL_CONTEXT.CANCEL &&
-                                <Tooltips
-                                    name={keymap.MODAL_CONTEXT.CANCEL}
-                                    action={counterpart.translate('modal.actions.cancel')}
-                                    type={''}
-                                />
-                            }
-                        </button>}
-                        <button
-                            className={
-                                `btn btn-meta-outline-secondary
-                                btn-distance-3 btn-md `+
-                                (pending ? 'tag-disabled disabled ' : '')
-                            }
-                            onClick={this.handleClose}
-                            tabIndex={0}
-                            onMouseEnter={() =>
-                                this.toggleTooltip(modalType === 'process' ? keymap.MODAL_CONTEXT.CANCEL : keymap.MODAL_CONTEXT.APPLY)
-                            }
-                            onMouseLeave={this.toggleTooltip}
-                        >
-                            {modalType === 'process' ?
-                                counterpart.translate('modal.actions.cancel') :
-                                counterpart.translate('modal.actions.done')
-                            }
-                            {isTooltipShow === (modalType === 'process' ? keymap.MODAL_CONTEXT.CANCEL : keymap.MODAL_CONTEXT.APPLY) &&
-                                <Tooltips
-                                    name={modalType === 'process' ? keymap.MODAL_CONTEXT.CANCEL : keymap.MODAL_CONTEXT.APPLY}
-                                    action={modalType === 'process' ?
-                                        counterpart.translate('modal.actions.cancel') :
-                                        counterpart.translate('modal.actions.done')
+        return Object.keys(data).length > 0 && (
+            <div className="screen-freeze js-not-unselect">
+                <div className="panel panel-modal panel-modal-primary">
+                    <div
+                        className={
+                            'panel-modal-header ' +
+                            (scrolled ? 'header-shadow': '')
+                        }
+                    >
+                        <span className="panel-modal-header-title">
+                            {modalTitle ? modalTitle : layout.caption}
+                        </span>
+
+                        <div className="items-row-2">
+                            {isNewDoc && (
+                                <button
+                                    className={
+                                        `btn btn-meta-outline-secondary
+                                        btn-distance-3 btn-md ${pending ?
+                                            'tag-disabled disabled ' : ''}`
                                     }
-                                    type={''}
-                                />
-                            }
-                        </button>
-                        {modalType === 'process' &&
+                                    onClick={this.removeModal}
+                                    tabIndex={0}
+                                    onMouseEnter={() => this.toggleTooltip(
+                                        keymap.MODAL_CONTEXT.CANCEL
+                                    )}
+                                    onMouseLeave={this.toggleTooltip}
+                                >
+                                    {counterpart.translate(
+                                        'modal.actions.cancel',
+                                    )}
+
+                                    {(isTooltipShow ===
+                                        keymap.MODAL_CONTEXT.CANCEL
+                                    ) && (
+                                        <Tooltips
+                                            name={keymap.MODAL_CONTEXT.CANCEL}
+                                            action={counterpart.translate(
+                                                'modal.actions.cancel',
+                                            )}
+                                            type=""
+                                        />
+                                    )}
+                                </button>
+                            )}
+
                             <button
                                 className={
-                                    `btn btn-meta-primary btn-distance-3
-                                    btn-md ` +
-                                    (pending ? 'tag-disabled disabled' : '')
+                                    `btn btn-meta-outline-secondary
+                                    btn-distance-3 btn-md `+
+                                    (pending ? 'tag-disabled disabled ' : '')
                                 }
-                                onClick={this.handleStart}
+                                onClick={this.handleClose}
                                 tabIndex={0}
-                                onMouseEnter={() =>
-                                    this.toggleTooltip(keymap.MODAL_CONTEXT.APPLY)
-                                }
+                                onMouseEnter={() => this.toggleTooltip(
+                                    modalType === 'process' ?
+                                        keymap.MODAL_CONTEXT.CANCEL :
+                                        keymap.MODAL_CONTEXT.APPLY
+                                )}
                                 onMouseLeave={this.toggleTooltip}
                             >
-                                {counterpart.translate('modal.actions.start')}
-                                {isTooltipShow === keymap.MODAL_CONTEXT.APPLY &&
-                                    <Tooltips
-                                        name={keymap.MODAL_CONTEXT.APPLY}
-                                        action={counterpart.translate('modal.actions.start')}
-                                        type={''}
-                                    />
+                                {modalType === 'process' ?
+                                    counterpart.translate(
+                                        'modal.actions.cancel',
+                                    ) : counterpart.translate(
+                                        'modal.actions.done',
+                                    )
                                 }
+
+                                {isTooltipShow === (modalType === 'process' ?
+                                    keymap.MODAL_CONTEXT.CANCEL :
+                                    keymap.MODAL_CONTEXT.APPLY
+                                ) && (
+                                    <Tooltips
+                                        name={modalType === 'process' ?
+                                            keymap.MODAL_CONTEXT.CANCEL :
+                                            keymap.MODAL_CONTEXT.APPLY
+                                        }
+                                        action={modalType === 'process' ?
+                                            counterpart.translate(
+                                                'modal.actions.cancel',
+                                            ) : counterpart.translate(
+                                                'modal.actions.done',
+                                            )
+                                        }
+                                        type=""
+                                    />
+                                )}
                             </button>
-                        }
+
+                            {modalType === 'process' &&
+                                <button
+                                    className={
+                                        `btn btn-meta-primary btn-distance-3
+                                        btn-md ` +
+                                        (pending ? 'tag-disabled disabled' : '')
+                                    }
+                                    onClick={this.handleStart}
+                                    tabIndex={0}
+                                    onMouseEnter={() => this.toggleTooltip(
+                                        keymap.MODAL_CONTEXT.APPLY
+                                    )}
+                                    onMouseLeave={this.toggleTooltip}
+                                >
+                                    {counterpart.translate(
+                                        'modal.actions.start',
+                                    )}
+
+                                    {(isTooltipShow ===
+                                        keymap.MODAL_CONTEXT.APPLY
+                                    ) && (
+                                        <Tooltips
+                                            name={keymap.MODAL_CONTEXT.APPLY}
+                                            action={counterpart.translate(
+                                                'modal.actions.start',
+                                            )}
+                                            type=""
+                                        />
+                                    )}
+                                </button>
+                            }
+                        </div>
                     </div>
+
+                    <Indicator isDocumentNotSaved={isDocumentNotSaved} />
+
+                    <div
+                        className={
+                            `panel-modal-content js-panel-modal-content
+                            container-fluid`
+                        }
+                        ref={c => { if (c) { c.focus(); } }}
+                    >
+                        {this.renderModalBody()}
+                    </div>
+
+                    <ModalContextShortcuts
+                        apply={modalType === 'process' ?
+                            this.handleStart :
+                            this.handleClose
+                        }
+                        cancel={modalType === 'process' ?
+                            this.handleClose :
+                            isNewDoc ?
+                                this.removeModal :
+                                ''
+                        }
+                    />
                 </div>
-                <Indicator {...{isDocumentNotSaved}}/>
-                <div
-                    className={
-                        `panel-modal-content js-panel-modal-content
-                        container-fluid`
-                    }
-                    ref={c => { c && c.focus()}}
-                >
-                    {this.renderModalBody()}
-                </div>
-                <ModalContextShortcuts
-                    apply={modalType === 'process' ? this.handleStart : this.handleClose}
-                    cancel={modalType === 'process' ? this.handleClose : isNewDoc ? this.removeModal : ''}
-                />
             </div>
-        </div>
         )
     }
 
     renderOverlay = () => {
-       const {
-            data, layout, windowType
-        } = this.props;
+       const { data, layout, windowType } = this.props;
+        const { pending } = this.state;
 
-        const {pending} = this.state;
-
-        return(
+        return (
             <OverlayField
                 type={windowType}
                 disabled={pending}
@@ -447,37 +475,24 @@ class Modal extends Component {
                 handleSubmit={this.setFetchOnTrue}
                 closeOverlay={this.removeModal}
             />
-        )
+        );
     }
 
     render() {
-        const {
-            layout
-        } = this.props;
+        const { layout } = this.props;
 
         return (
             <div>
-                {
-                    (!layout.layoutType || layout.layoutType === 'panel') &&
+                {(!layout.layoutType || layout.layoutType === 'panel') && (
                     this.renderPanel()
-                }
-                {
-                    layout.layoutType === 'singleOverlayField' &&
+                )}
+
+                {layout.layoutType === 'singleOverlayField' && (
                     this.renderOverlay()
-                }
+                )}
             </div>
-        )
+        );
     }
 }
 
-Modal.childContextTypes = {
-    shortcuts: PropTypes.object.isRequired
-}
-
-Modal.propTypes = {
-    dispatch: PropTypes.func.isRequired
-};
-
-Modal = connect()(Modal);
-
-export default Modal
+export default connect()(Modal);

--- a/src/components/app/QuickActions.js
+++ b/src/components/app/QuickActions.js
@@ -49,10 +49,6 @@ class QuickActions extends Component {
             selected, viewId, windowType
         } = this.props;
 
-        if (nextProps.selectedWindowType && (nextProps.selectedWindowType !== nextProps.windowType)) {
-            return;
-        }
-
         if (
             (nextProps.selected && (JSON.stringify(nextProps.selected) !== JSON.stringify(selected))) ||
             (nextProps.viewId && (nextProps.viewId !== viewId)) ||

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -31,8 +31,6 @@ import UserDropdown from './UserDropdown';
 const shortcutManager = new ShortcutManager(keymap);
 
 const mapStateToProps = state => ({
-    selected: state.windowHandler.selected,
-    selectedWindowType: state.windowHandler.selectedWindowType,
     inbox: state.appHandler.inbox,
     me: state.appHandler.me,
     pathname: state.routing.locationBeforeTransitions.pathname,
@@ -59,7 +57,6 @@ class Header extends Component {
 
     static propTypes = {
         dispatch: PropTypes.func.isRequired,
-        selected: PropTypes.array.isRequired,
         inbox: PropTypes.object.isRequired,
         me: PropTypes.object.isRequired,
     }
@@ -307,9 +304,8 @@ class Header extends Component {
         const {
             docSummaryData, siteName, docNoData, docStatus,
             docStatusData, windowType, dataId, breadcrumb, showSidelist,
-            inbox, selected, entity, query, showIndicator, isDocumentNotSaved,
-            selectedWindowType, notfound, docId, me, editmode,
-            handleEditModeToggle, activeTab,
+            inbox, entity, query, showIndicator, isDocumentNotSaved, notfound,
+            docId, me, editmode, handleEditModeToggle, activeTab,
         } = this.props;
         const {
             isSubheaderShow, isSideListShow, menuOverlay, isInboxOpen, scrolled,
@@ -596,10 +592,9 @@ class Header extends Component {
                     notfound={notfound}
                     query={query}
                     entity={entity}
-                    selectedWindowType={selectedWindowType}
-                    selected={selected}
                     dataId={dataId}
                     windowType={windowType}
+                    viewId={query.viewId}
                     siteName={siteName}
                     editmode={editmode}
                     handleEditModeToggle={handleEditModeToggle}

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,58 +1,67 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
-import {push, replace} from 'react-router-redux';
 import counterpart from 'counterpart';
-
-import logo from '../../assets/images/metasfresh_logo_green_thumb.png';
-
-import Subheader from './SubHeader';
-import UserDropdown from './UserDropdown';
-import Breadcrumb from './Breadcrumb';
-import MasterWidget from '../widget/MasterWidget';
-import SideList from './SideList';
-import Indicator from '../app/Indicator';
-import Inbox from '../inbox/Inbox';
-import Tooltips from '../tooltips/Tooltips';
-import Prompt from '../app/Prompt';
-import NewEmail from '../email/NewEmail';
-import NewLetter from '../letter/NewLetter';
-
-import {
-    openModal,
-    closeModal
-} from '../../actions/WindowActions';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import { ShortcutManager } from 'react-shortcuts';
 
 import {
     deleteRequest,
     duplicateRequest,
-    openFile
+    openFile,
 } from '../../actions/GenericActions';
+import { openModal } from '../../actions/WindowActions';
+import logo from '../../assets/images/metasfresh_logo_green_thumb.png';
+import keymap from '../../keymap';
 
-import keymap from '../../keymap.js';
+import Indicator from '../app/Indicator';
+import Prompt from '../app/Prompt';
+import NewEmail from '../email/NewEmail';
+import Inbox from '../inbox/Inbox';
+import NewLetter from '../letter/NewLetter';
 import GlobalContextShortcuts from '../shortcuts/GlobalContextShortcuts';
-import { ShortcutManager } from 'react-shortcuts';
+import Tooltips from '../tooltips/Tooltips';
+import MasterWidget from '../widget/MasterWidget';
+
+import Breadcrumb from './Breadcrumb';
+import SideList from './SideList';
+import Subheader from './SubHeader';
+import UserDropdown from './UserDropdown';
+
 const shortcutManager = new ShortcutManager(keymap);
 
-class Header extends Component {
-    constructor(props){
-        super(props);
+const mapStateToProps = state => ({
+    selected: state.windowHandler.selected,
+    selectedWindowType: state.windowHandler.selectedWindowType,
+    inbox: state.appHandler.inbox,
+    me: state.appHandler.me,
+    pathname: state.routing.locationBeforeTransitions.pathname,
+});
 
-        this.state = {
-            isSubheaderShow: false,
-            isSideListShow: false,
-            sideListTab: null,
-            isMenuOverlayShow: false,
-            menuOverlay: null,
-            scrolled: false,
-            isInboxOpen: false,
-            isUDOpen: false,
-            tooltipOpen: '',
-            isEmailOpen: false,
-            prompt: {
-                open: false
-            }
-        }
+class Header extends Component {
+    state = {
+        isSubheaderShow: false,
+        isSideListShow: false,
+        sideListTab: null,
+        isMenuOverlayShow: false,
+        menuOverlay: null,
+        scrolled: false,
+        isInboxOpen: false,
+        isUDOpen: false,
+        tooltipOpen: '',
+        isEmailOpen: false,
+        prompt: { open: false },
+    }
+
+    static childContextTypes = {
+        shortcuts: PropTypes.object.isRequired,
+    }
+
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+        selected: PropTypes.array.isRequired,
+        inbox: PropTypes.object.isRequired,
+        me: PropTypes.object.isRequired,
     }
 
     componentDidMount() {
@@ -64,34 +73,35 @@ class Header extends Component {
         this.removeEventListeners();
     }
 
-    componentWillUpdate = (nextProps) => {
-        const {dropzoneFocused} = this.props;
-        if(
-            nextProps.dropzoneFocused !== dropzoneFocused &&
+    componentWillUpdate(nextProps) {
+        const { dropzoneFocused } = this.props;
+
+        if (nextProps.dropzoneFocused !== dropzoneFocused &&
             nextProps.dropzoneFocused
-        ){
+        ) {
             this.closeOverlays();
         }
     }
 
-    componentDidUpdate = (prevProps) => {
-        const {dispatch, pathname} = this.props;
-        if(
-            prevProps.me.language !== undefined &&
+    componentDidUpdate(prevProps) {
+        // const {dispatch, pathname} = this.props;
+
+        if (prevProps.me.language !== undefined &&
             JSON.stringify(prevProps.me.language) !==
             JSON.stringify(this.props.me.language)
         ) {
-/*
+            /*
             dispatch(replace(''));
             dispatch(replace(pathname));
-*/
+            */
+
             // Need to reload page completely when current locale gets changed
             window.location.reload(false);
         }
     }
 
     getChildContext = () => {
-        return { shortcuts: shortcutManager }
+        return { shortcuts: shortcutManager };
     }
 
     initEventListeners = () => {
@@ -103,38 +113,33 @@ class Header extends Component {
     }
 
     handleInboxOpen = (state) => {
-        this.setState({
-            isInboxOpen: !!state
-        });
+        this.setState({ isInboxOpen: !!state });
     }
 
     handleUDOpen = (state) => {
-        this.setState({
-            isUDOpen: !!state
-        })
+        this.setState({ isUDOpen: !!state })
     }
 
     handleMenuOverlay = (e, nodeId) => {
-        const {isSubheaderShow, isSideListShow} = this.state;
-        e && e.preventDefault();
+        const { isSubheaderShow, isSideListShow } = this.state;
+
+        if (e) {
+            e.preventDefault();
+        }
 
         let toggleBreadcrumb = () => {
             this.setState({
-                menuOverlay: nodeId
+                menuOverlay: nodeId,
             }, () => {
-                if(nodeId !== '') {
-                    this.setState({
-                        isMenuOverlayShow: true
-                    });
+                if (nodeId !== '') {
+                    this.setState({ isMenuOverlayShow: true });
                 } else {
-                    this.setState({
-                        isMenuOverlayShow: false
-                    });
+                    this.setState({ isMenuOverlayShow: false });
                 }
             });
         }
 
-        if(!isSubheaderShow && !isSideListShow){
+        if (!isSubheaderShow && !isSideListShow) {
             toggleBreadcrumb();
         }
     }
@@ -143,45 +148,39 @@ class Header extends Component {
         const target = event.srcElement;
         let scrollTop = target && target.body.scrollTop;
 
-        if(!scrollTop){
+        if (!scrollTop) {
             scrollTop = document.documentElement.scrollTop;
         }
 
-        if(scrollTop > 0) {
-            this.setState({
-                scrolled: true
-            })
+        if (scrollTop > 0) {
+            this.setState({ scrolled: true });
         } else {
-            this.setState({
-                scrolled: false
-            })
+            this.setState({ scrolled: false });
         }
     }
 
     handleDashboardLink = () => {
-        const {dispatch} = this.props;
+        const { dispatch } = this.props;
         dispatch(push('/'));
     }
 
     toggleScrollScope = (open) => {
-        if(!open){
+        if (!open) {
             document.body.style.overflow = 'auto';
-        }else{
+        } else {
             document.body.style.overflow = 'hidden';
         }
     }
 
     toggleTooltip = (tooltip) => {
-        this.setState({
-            tooltipOpen: tooltip
-        });
+        this.setState({ tooltipOpen: tooltip });
     }
 
     openModal = (windowType, type, caption, isAdvanced) => {
-        const {dispatch, query} = this.props;
+        const { dispatch, query } = this.props;
         dispatch(openModal(
             caption, windowType, type, null, null, isAdvanced,
-            query && query.viewId
+            query && query.viewId,
         ));
     }
 
@@ -189,14 +188,14 @@ class Header extends Component {
         const { dispatch } = this.props;
 
         dispatch(openModal(
-            caption, windowType, type, tabId, rowId
+            caption, windowType, type, tabId, rowId,
         ));
     }
 
     handlePrint = (windowType, docId, docNo) => {
         openFile(
             'window', windowType, docId, 'print',
-            windowType + '_' + (docNo ? docNo : docId) + '.pdf'
+            windowType + '_' + (docNo ? docNo : docId) + '.pdf',
         );
     }
 
@@ -204,62 +203,46 @@ class Header extends Component {
         const { dispatch } = this.props;
 
         duplicateRequest('window', windowType, docId)
-            .then( (response) => {
+            .then((response) => {
                 if (response && response.data && response.data.id) {
-                    dispatch(
-                        push(`/window/${windowType}/${response.data.id}`)
-                    );
+                    dispatch(push(`/window/${windowType}/${response.data.id}`));
                 }
             });
     }
 
     handleDelete = () => {
         this.setState({
-            prompt: Object.assign({}, this.state.prompt, {
-                open: true
-            })
+            prompt: Object.assign({}, this.state.prompt, { open: true }),
         });
     }
 
     handleEmail = () => {
-        this.setState({
-            isEmailOpen: true
-        });
+        this.setState({ isEmailOpen: true });
     }
 
     handleLetter = () => {
-        this.setState({
-            isLetterOpen: true
-        });
+        this.setState({ isLetterOpen: true });
     }
 
     handleCloseEmail = () => {
-        this.setState({
-            isEmailOpen: false
-        });
+        this.setState({ isEmailOpen: false });
     }
 
     handleCloseLetter = () => {
-        this.setState({
-            isLetterOpen: false
-        });
+        this.setState({ isLetterOpen: false });
     }
 
     handlePromptCancelClick = () => {
         this.setState({
-            prompt: Object.assign({}, this.state.prompt, {
-                open: false
-            })
+            prompt: Object.assign({}, this.state.prompt, { open: false }),
         });
     }
 
     handlePromptSubmitClick = (windowType, docId) => {
-        const {dispatch, handleDeletedStatus} = this.props;
+        const { dispatch, handleDeletedStatus } = this.props;
 
         this.setState({
-            prompt: Object.assign({}, this.state.prompt, {
-                open: false
-            })
+            prompt: Object.assign({}, this.state.prompt, { open: false }),
         }, () => {
             deleteRequest('window', windowType, null, null, [docId])
                 .then(() => {
@@ -273,10 +256,10 @@ class Header extends Component {
     handleDocStatusToggle = (close) => {
         const elem = document.getElementsByClassName('js-dropdown-toggler')[0];
 
-        if(close) {
+        if (close) {
             elem.blur();
         } else {
-            if(document.activeElement === elem) {
+            if (document.activeElement === elem) {
                 elem.blur();
             } else {
                 elem.focus();
@@ -285,17 +268,16 @@ class Header extends Component {
     }
 
     handleSidelistToggle = (id = null, sideListTab) => {
-
         this.toggleScrollScope(id !== null);
 
         this.setState({
             isSideListShow: id !== null && id !== sideListTab,
-            sideListTab: id !== sideListTab ? id : null
+            sideListTab: id !== sideListTab ? id : null,
         });
     }
 
     closeOverlays = (clickedItem, callback) => {
-        const {isSubheaderShow} = this.state;
+        const { isSubheaderShow } = this.state;
 
         this.setState({
             menuOverlay: null,
@@ -306,19 +288,18 @@ class Header extends Component {
             sideListTab: null,
             isSubheaderShow:
                 (clickedItem == 'isSubheaderShow' ? !isSubheaderShow : false),
-            tooltipOpen: ''
+            tooltipOpen: '',
         }, callback);
 
-        if(
-            document.getElementsByClassName('js-dropdown-toggler')[0] &&
-            (clickedItem != 'dropdown')
-        ){
+        if (document.getElementsByClassName('js-dropdown-toggler')[0] &&
+            (clickedItem !== 'dropdown')
+        ) {
             this.handleDocStatusToggle(true);
         }
     }
 
     redirect = (where) => {
-        const {dispatch} = this.props;
+        const { dispatch } = this.props;
         dispatch(push(where));
     }
 
@@ -328,29 +309,27 @@ class Header extends Component {
             docStatusData, windowType, dataId, breadcrumb, showSidelist,
             inbox, selected, entity, query, showIndicator, isDocumentNotSaved,
             selectedWindowType, notfound, docId, me, editmode,
-            handleEditModeToggle, activeTab
+            handleEditModeToggle, activeTab,
         } = this.props;
-
         const {
             isSubheaderShow, isSideListShow, menuOverlay, isInboxOpen, scrolled,
             isMenuOverlayShow, tooltipOpen, prompt, sideListTab, isUDOpen,
-            isEmailOpen, isLetterOpen
+            isEmailOpen, isLetterOpen,
         } = this.state;
 
         return (
             <div>
-            {
-                prompt.open &&
-                <Prompt
-                    title="Delete"
-                    text="Are you sure?"
-                    buttons={{submit: 'Delete', cancel: 'Cancel'}}
-                    onCancelClick={this.handlePromptCancelClick}
-                    onSubmitClick={() =>
-                        this.handlePromptSubmitClick(windowType, dataId)
-                    }
-                />
-            }
+                {prompt.open && (
+                    <Prompt
+                        title="Delete"
+                        text="Are you sure?"
+                        buttons={{ submit: 'Delete', cancel: 'Cancel' }}
+                        onCancelClick={this.handlePromptCancelClick}
+                        onSubmitClick={() =>
+                            this.handlePromptSubmitClick(windowType, dataId)
+                        }
+                    />
+                )}
 
                 <nav
                     className={
@@ -397,14 +376,19 @@ class Header extends Component {
                                                 'mainScreen.actionMenu.tooltip'
                                                 )
                                             }
-                                            type={''}
+                                            type=""
                                         /> }
                                 </div>
 
                                 <Breadcrumb
-                                    {...{breadcrumb, windowType, docSummaryData,
-                                        dataId, siteName, menuOverlay, docId,
-                                        isDocumentNotSaved}}
+                                    breadcrumb={breadcrumb}
+                                    windowType={windowType}
+                                    docSummaryData={docSummaryData}
+                                    dataId={dataId}
+                                    siteName={siteName}
+                                    menuOverlay={menuOverlay}
+                                    docId={docId}
+                                    isDocumentNotSaved={isDocumentNotSaved}
                                     handleMenuOverlay={this.handleMenuOverlay}
                                     openModal={this.openModal}
                                 />
@@ -414,7 +398,7 @@ class Header extends Component {
                                 <img
                                     src={logo}
                                     className="header-logo pointer"
-                                    onClick={() => this.handleDashboardLink()}
+                                    onClick={this.handleDashboardLink}
                                 />
                             </div>
                             <div className="header-right-side">
@@ -438,7 +422,7 @@ class Header extends Component {
                                             windowType={windowType}
                                             dataId={dataId}
                                             widgetData={[docStatusData]}
-                                            noLabel={true}
+                                            noLabel
                                             type="primary"
                                             dropdownOpenCallback={()=>{
                                                 this.closeOverlays('dropdown')
@@ -460,7 +444,7 @@ class Header extends Component {
                                                 'mainScreen.docStatus.tooltip'
                                                 )
                                                 }
-                                                type={''}
+                                                type=""
                                             />
                                         }
                                     </div>
@@ -533,9 +517,11 @@ class Header extends Component {
                                     disableOnClickOutside={!isUDOpen}
                                     redirect={this.redirect}
                                     shortcut={
-                                        keymap.GLOBAL_CONTEXT.OPEN_AVATAR_MENU}
+                                        keymap.GLOBAL_CONTEXT.OPEN_AVATAR_MENU
+                                    }
                                     toggleTooltip={this.toggleTooltip}
-                                    {...{tooltipOpen, me}}
+                                    tooltipOpen={tooltipOpen}
+                                    me={me}
                                 />
 
                                 {showSidelist &&
@@ -574,12 +560,12 @@ class Header extends Component {
                                                         .GLOBAL_CONTEXT
                                                         .OPEN_SIDEBAR_MENU_0
                                                 }
-                                                action={
-                                                    counterpart.translate(
+                                                action={counterpart.translate(
+                                                    /* eslint-disable max-len */
                                                     'mainScreen.sideList.tooltip'
-                                                    )
-                                                }
-                                                type={''}
+                                                    /* eslint-enable max-len */
+                                                )}
+                                                type=""
                                             />
                                         }
 
@@ -588,7 +574,10 @@ class Header extends Component {
                             </div>
                         </div>
                     </div>
-                    {showIndicator && <Indicator {...{isDocumentNotSaved}}/>}
+
+                    {showIndicator && (
+                        <Indicator isDocumentNotSaved={isDocumentNotSaved} />
+                    )}
                 </nav>
 
                 {isSubheaderShow && <Subheader
@@ -603,10 +592,18 @@ class Header extends Component {
                     handleLetter={this.handleLetter}
                     redirect={this.redirect}
                     disableOnClickOutside={!isSubheaderShow}
-                    {...{breadcrumb, notfound, query, entity,
-                        selectedWindowType, selected, dataId, windowType,
-                        siteName, editmode, handleEditModeToggle, activeTab
-                    }}
+                    breadcrumb={breadcrumb}
+                    notfound={notfound}
+                    query={query}
+                    entity={entity}
+                    selectedWindowType={selectedWindowType}
+                    selected={selected}
+                    dataId={dataId}
+                    windowType={windowType}
+                    siteName={siteName}
+                    editmode={editmode}
+                    handleEditModeToggle={handleEditModeToggle}
+                    activeTab={activeTab}
                 />}
 
                 {showSidelist && isSideListShow && <SideList
@@ -617,7 +614,7 @@ class Header extends Component {
                     disableOnClickOutside={!showSidelist}
                     docId={dataId}
                     defaultTab={sideListTab}
-                    open={true}
+                    open
                 />}
 
                 {   isEmailOpen &&
@@ -641,7 +638,7 @@ class Header extends Component {
                     handleMenuOverlay={isMenuOverlayShow ?
                         () => this.handleMenuOverlay('', '') :
                         () => this.closeOverlays('',
-                            ()=> this.handleMenuOverlay('', '0')
+                            () => this.handleMenuOverlay('', '0')
                         )
                     }
                     handleInboxOpen = {isInboxOpen ?
@@ -678,51 +675,4 @@ class Header extends Component {
     }
 }
 
-Header.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    selected: PropTypes.array.isRequired,
-    inbox: PropTypes.object.isRequired,
-    me: PropTypes.object.isRequired
-};
-
-function mapStateToProps(state) {
-    const {windowHandler, appHandler, routing} = state;
-
-    const {
-        inbox,
-        me
-    } = appHandler || {
-        inbox: {},
-        me: {}
-    }
-
-    const {
-        selected,
-        selectedWindowType
-    } = windowHandler || {
-        selected: [],
-        selectedWindowType: null
-    }
-
-    const {
-        pathname
-    } = routing.locationBeforeTransitions || {
-        pathname: ''
-    }
-
-    return {
-        selected,
-        inbox,
-        selectedWindowType,
-        me,
-        pathname
-    }
-}
-
-Header.childContextTypes = {
-    shortcuts: PropTypes.object.isRequired
-}
-
-Header = connect(mapStateToProps)(Header)
-
-export default Header
+export default connect(mapStateToProps)(Header);

--- a/src/components/header/SubHeader.js
+++ b/src/components/header/SubHeader.js
@@ -8,13 +8,19 @@ import {
   elementPathRequest,
   updateBreadcrumb,
 } from '../../actions/MenuActions';
+import { getSelection } from '../../reducers/windowHandler';
 import keymap from '../../keymap.js';
 
 import Actions from './Actions';
 import BookmarkButton from './BookmarkButton';
 
-const mapStateToProps = state => ({
-    standardActions: state.windowHandler.master.standardActions
+const mapStateToProps = (state, props) => ({
+    standardActions: state.windowHandler.master.standardActions,
+    selected: getSelection({
+        state,
+        windowType: props.windowType,
+        viewId: props.viewId,
+    }),
 });
 
 class Subheader extends Component {
@@ -331,8 +337,8 @@ class Subheader extends Component {
 
     renderActionsColumn = () => {
         const {
-            windowType, dataId, selected, selectedWindowType, entity, query,
-            openModal, openModalRow, closeSubheader, notfound, activeTab,
+            windowType, dataId, selected, entity, query, openModal,
+            openModalRow, closeSubheader, notfound, activeTab,
         } = this.props;
 
         return (
@@ -345,9 +351,11 @@ class Subheader extends Component {
                 closeSubheader={closeSubheader}
                 notfound={notfound}
                 docId={dataId ? dataId : query && query.viewId}
-                rowId={selectedWindowType === windowType ? selected : []}
+                rowId={selected}
                 activeTab={activeTab}
-                activeTabSelected={(activeTab && selected && (selected.length === 1)) ? selected: []}
+                activeTabSelected={(
+                    activeTab && selected && (selected.length === 1)
+                ) ? selected : []}
             />
         );
 

--- a/src/components/header/SubHeader.js
+++ b/src/components/header/SubHeader.js
@@ -1,25 +1,30 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
-import onClickOutside from 'react-onclickoutside';
 import counterpart from 'counterpart';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import onClickOutside from 'react-onclickoutside';
+import { connect } from 'react-redux';
 
-import {updateBreadcrumb, elementPathRequest} from '../../actions/MenuActions';
-
-import Actions from './Actions';
-
-import BookmarkButton from './BookmarkButton';
-
+import {
+  elementPathRequest,
+  updateBreadcrumb,
+} from '../../actions/MenuActions';
 import keymap from '../../keymap.js';
 
-class Subheader extends Component {
-    constructor(props){
-        super(props);
+import Actions from './Actions';
+import BookmarkButton from './BookmarkButton';
 
-        this.state = {
-            pdfSrc: null,
-            elementPath: ''
-        }
+const mapStateToProps = state => ({
+    standardActions: state.windowHandler.master.standardActions
+});
+
+class Subheader extends Component {
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+    }
+
+    state = {
+        pdfSrc: null,
+        elementPath: '',
     }
 
     componentDidMount() {
@@ -28,58 +33,61 @@ class Subheader extends Component {
         const entity = (this.props.entity === 'board') ? 'board' : 'window';
 
         elementPathRequest(entity, this.props.windowType).then(response => {
-            this.setState({
-                elementPath: response.data
-            });
+            this.setState({ elementPath: response.data });
         });
     }
 
     handleKeyDown = (e) => {
-        const {closeSubheader} = this.props;
+        const { closeSubheader } = this.props;
 
-        switch(e.key){
+        switch (e.key) {
             case 'ArrowDown': {
                 e.preventDefault();
                 const activeElem = this.getItemActiveElem();
-                if(activeElem.nextSibling) {
+                if (activeElem.nextSibling) {
                     activeElem.nextSibling.focus();
                 }
                 break;
             }
+
             case 'ArrowUp': {
                 e.preventDefault();
                 const activeEl = this.getItemActiveElem();
-                if(activeEl.previousSibling) {
+                if (activeEl.previousSibling) {
                     activeEl.previousSibling.focus();
                 }
                 break;
             }
+
             case 'ArrowLeft': {
                 e.preventDefault();
                 const activeColumn = this.getColumnActiveElem();
-                if(activeColumn.previousSibling) {
+                if (activeColumn.previousSibling) {
                     activeColumn.previousSibling.focus();
-                    if(this.getItemActiveElem().nextSibling) {
+                    if (this.getItemActiveElem().nextSibling) {
                          this.getItemActiveElem().nextSibling.focus();
                     }
                 }
                 break;
             }
+
             case 'ArrowRight': {
                 e.preventDefault();
                 const activeCol = this.getColumnActiveElem();
-                if(activeCol.nextSibling) {
+                if (activeCol.nextSibling) {
                     activeCol.nextSibling.focus();
-                    if(this.getItemActiveElem().nextSibling){
+                    if (this.getItemActiveElem().nextSibling){
                         this.getItemActiveElem().nextSibling.focus();
                     }
                 }
                 break;
             }
+
             case 'Enter':
                 e.preventDefault();
                 document.activeElement.click();
                 break;
+
             case 'Escape':
                 e.preventDefault();
                 closeSubheader();
@@ -93,25 +101,22 @@ class Subheader extends Component {
     }
 
     toggleAttachmentDelete = (value) => {
-        this.setState({
-            attachmentHovered: value
-        })
+        this.setState({ attachmentHovered: value });
     }
 
     getColumnActiveElem = () => {
         const active = document.activeElement;
-        if(active.classList.contains('js-subheader-item')) {
+        if (active.classList.contains('js-subheader-item')) {
             return active.parentNode;
         } else {
-             return active;
+            return active;
         }
     }
 
     getItemActiveElem = () => {
         const active = document.activeElement;
-        if(
-            active.classList.contains('js-subheader-column')
-        ) {
+
+        if (active.classList.contains('js-subheader-column')) {
             return active.childNodes[1];
         } else {
             return active;
@@ -119,11 +124,11 @@ class Subheader extends Component {
     }
 
     handleUpdateBreadcrumb = (nodes) => {
-        const {dispatch} = this.props;
+        const { dispatch } = this.props;
         nodes.map(node => dispatch(updateBreadcrumb(node)));
     }
 
-    handleDownloadSelected = event => {
+    handleDownloadSelected = (event) => {
         if (this.props.selected.length === 0) {
             event.preventDefault();
         }
@@ -143,10 +148,10 @@ class Subheader extends Component {
                 }}
             >
                 <i className={icon} />
+
                 {caption}
-                <span className="tooltip-inline">
-                    {hotkey}
-                </span>
+
+                <span className="tooltip-inline">{hotkey}</span>
             </div>
         );
     }
@@ -162,7 +167,7 @@ class Subheader extends Component {
             handlePrint,
             openModal,
             standardActions,
-            windowType
+            windowType,
         } = this.props;
 
         if (!dataId) {
@@ -236,12 +241,9 @@ class Subheader extends Component {
             redirect,
             selected,
             siteName,
-            windowType
+            windowType,
         } = this.props;
-
-        const {
-            elementPath
-        } = this.state;
+        const { elementPath } = this.state;
 
         let currentNode = elementPath;
         if (currentNode && currentNode.children) {
@@ -255,9 +257,7 @@ class Subheader extends Component {
                 className="subheader-column js-subheader-column"
                 tabIndex={0}
             >
-                <div
-                    className="subheader-header"
-                >
+                <div className="subheader-header">
                     <BookmarkButton
                         isBookmark={currentNode && currentNode.favorite}
                         nodeId={currentNode && currentNode.nodeId}
@@ -268,25 +268,34 @@ class Subheader extends Component {
                             title={
                                 currentNode ? currentNode.caption : siteName
                             }
-                            className="subheader-title">
-                                {currentNode ? currentNode.caption : siteName}
+                            className="subheader-title"
+                        >
+                            {currentNode ? currentNode.caption : siteName}
                         </span>
                     </BookmarkButton>
                 </div>
+
                 <div className="subheader-break" />
-                {windowType && <div
-                    className="subheader-item js-subheader-item"
-                    tabIndex={0}
-                    onClick={() => { redirect(
-                        '/window/'+ windowType + '/new'
-                    ); closeSubheader()}
-                }>
-                    <i className="meta-icon-report-1" />
-                    {counterpart.translate('window.new.caption')}
-                    <span className="tooltip-inline">
-                        {keymap.GLOBAL_CONTEXT.NEW_DOCUMENT}
-                    </span>
-                </div>}
+
+                {windowType && (
+                    <div
+                        className="subheader-item js-subheader-item"
+                        tabIndex={0}
+                        onClick={() => {
+                            redirect('/window/'+ windowType + '/new');
+                            closeSubheader();
+                        }}
+                    >
+                        <i className="meta-icon-report-1" />
+
+                        {counterpart.translate('window.new.caption')}
+
+                        <span className="tooltip-inline">
+                            {keymap.GLOBAL_CONTEXT.NEW_DOCUMENT}
+                        </span>
+                    </div>
+                )}
+
                 {windowType && query && query.viewId && (
                     <a
                         className="subheader-item js-subheader-item"
@@ -323,15 +332,18 @@ class Subheader extends Component {
     renderActionsColumn = () => {
         const {
             windowType, dataId, selected, selectedWindowType, entity, query,
-            openModal, openModalRow, closeSubheader, notfound, activeTab
+            openModal, openModalRow, closeSubheader, notfound, activeTab,
         } = this.props;
 
         return (
             <Actions
                 key={1}
-                {...{
-                    windowType, entity, openModal, openModalRow, closeSubheader, notfound
-                }}
+                windowType={windowType}
+                entity={entity}
+                openModal={openModal}
+                openModalRow={openModalRow}
+                closeSubheader={closeSubheader}
+                notfound={notfound}
                 docId={dataId ? dataId : query && query.viewId}
                 rowId={selectedWindowType === windowType ? selected : []}
                 activeTab={activeTab}
@@ -342,13 +354,12 @@ class Subheader extends Component {
     }
 
     render() {
-
         return (
             <div
                 className="subheader-container overlay-shadow subheader-open js-not-unselect"
                 tabIndex={0}
                 onKeyDown={this.handleKeyDown}
-                ref={(c)=> this.subHeader = c}
+                ref={(c) => { this.subHeader = c; }}
             >
                 <div className="container-fluid-subheader container-fluid">
                     <div className="subheader-row">
@@ -361,12 +372,4 @@ class Subheader extends Component {
     }
 }
 
-Subheader.propTypes = {
-    dispatch: PropTypes.func.isRequired
-};
-
-Subheader = connect(state => ({
-    standardActions: state.windowHandler.master.standardActions
-}))(onClickOutside(Subheader));
-
-export default Subheader;
+export default connect(mapStateToProps)(onClickOutside(Subheader));

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -107,7 +107,11 @@ class Table extends Component {
             !disconnectFromState &&
             !_.isEqual(prevState.selected, selected)
         ) {
-            dispatch(selectTableItems(selected, type));
+            dispatch(selectTableItems({
+                windowType: type,
+                viewId,
+                ids: selected,
+            }));
         }
 
         if (!_.isEqual(prevProps.rowData, rowData)) {
@@ -274,7 +278,13 @@ class Table extends Component {
     }
 
     selectProduct = (id, idFocused, idFocusedDown) => {
-        const {dispatch, type, disconnectFromState, tabInfo} = this.props;
+        const {
+            dispatch,
+            type,
+            disconnectFromState,
+            tabInfo,
+            viewId,
+        } = this.props;
 
         this.setState(prevState => ({
             selected: prevState.selected.concat([id])
@@ -285,7 +295,14 @@ class Table extends Component {
                 dispatch(selectRow(selected));
             }
 
-            !disconnectFromState && dispatch(selectTableItems(selected, type))
+            if (!disconnectFromState) {
+                dispatch(selectTableItems({
+                    windowType: type,
+                    viewId,
+                    ids: selected,
+                }));
+            }
+
             this.triggerFocus(idFocused, idFocusedDown);
         })
     }

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -10,7 +10,6 @@ import DraggableWrapper from '../components/dashboard/DraggableWrapper';
 const mapStateToProps = state => ({
     modal: state.windowHandler.modal,
     rawModal: state.windowHandler.rawModal,
-    selected: state.windowHandler.selected,
     indicator: state.windowHandler.indicator,
     includedView: state.listHandler.includedView,
     enableTutorial: state.appHandler.enableTutorial,
@@ -57,8 +56,8 @@ export class Dashboard extends Component {
 
     render() {
         const {
-            location, modal, selected, rawModal, indicator, processStatus,
-            includedView, enableTutorial,
+            location, modal, rawModal, indicator, processStatus, includedView,
+            enableTutorial,
         } = this.props;
         const { editmode, hintsEnabled, introHints } = this.state;
 
@@ -69,7 +68,6 @@ export class Dashboard extends Component {
                 handleEditModeToggle={this.toggleEditMode}
                 modal={modal}
                 rawModal={rawModal}
-                selected={selected}
                 indicator={indicator}
                 processStatus={processStatus}
                 includedView={includedView}

--- a/src/containers/Dashboard.js
+++ b/src/containers/Dashboard.js
@@ -1,28 +1,40 @@
-import React, { Component } from 'react';
+import { Hints } from 'intro.js-react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {connect} from 'react-redux';
+
 import Container from '../components/Container';
 import DraggableWrapper from '../components/dashboard/DraggableWrapper';
+// import { introHints } from '../components/intro/intro';
 
-import { Steps, Hints } from 'intro.js-react';
-import { introSteps, introHints } from '../components/intro/intro';
+const mapStateToProps = state => ({
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    selected: state.windowHandler.selected,
+    indicator: state.windowHandler.indicator,
+    includedView: state.listHandler.includedView,
+    enableTutorial: state.appHandler.enableTutorial,
+    processStatus: state.appHandler.processStatus,
+    me: state.appHandler.me,
+});
 
 export class Dashboard extends Component {
-    constructor(props){
-        super(props);
+    state = {
+        editmode: false,
+        hintsEnabled: null,
+        introHints: null,
+    }
 
-        this.state = {
-            editmode: false,
-            hintsEnabled: null,
-            introHints: null
-        };
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
     }
 
     componentDidUpdate() {
         // TODO: Resolve this hotfix
         return;
 
-        const {me} = this.props;
+        /*
+        const { me } = this.props;
 
         if (me) {
             let docIntroHints;
@@ -33,97 +45,50 @@ export class Dashboard extends Component {
 
             this.setState({
                 hintsEnabled: (docIntroHints && (docIntroHints.length > 0)),
-                introHints: docIntroHints
+                introHints: docIntroHints,
             });
         }
+        */
     }
 
-    toggleEditMode = () => this.setState(prev => ({editmode: !prev.editmode}));
+    toggleEditMode = () => {
+        this.setState(prevState => ({ editmode: !prevState.editmode }));
+    }
 
     render() {
         const {
             location, modal, selected, rawModal, indicator, processStatus,
-            includedView, enableTutorial
-    } = this.props;
-
+            includedView, enableTutorial,
+        } = this.props;
         const { editmode, hintsEnabled, introHints } = this.state;
 
         return (
             <Container
                 siteName="Dashboard"
-                noMargin={true}
+                noMargin
                 handleEditModeToggle={this.toggleEditMode}
-                {...{modal, rawModal, selected, indicator, processStatus,
-                    includedView, editmode}}
+                modal={modal}
+                rawModal={rawModal}
+                selected={selected}
+                indicator={indicator}
+                processStatus={processStatus}
+                includedView={includedView}
+                editmode={editmode}
             >
                 <div className="container-fluid dashboard-wrapper">
                     <DraggableWrapper
-                        {...{editmode}}
+                        editmode={editmode}
                         toggleEditMode={this.toggleEditMode}
                         dashboard={location.pathname}
                     />
                 </div>
 
-                { (enableTutorial && introHints && (introHints.length > 0)) && (
-                    <Hints
-                        enabled={hintsEnabled}
-                        hints={introHints}
-                    />
+                {(enableTutorial && introHints && (introHints.length > 0)) && (
+                    <Hints enabled={hintsEnabled} hints={introHints} />
                 )}
             </Container>
         );
     }
 }
 
-Dashboard.propTypes = {
-    dispatch: PropTypes.func.isRequired
-};
-
-function mapStateToProps(state) {
-    const {
-        windowHandler, listHandler, appHandler
-    } = state;
-
-    const {
-        modal,
-        rawModal,
-        selected,
-        indicator,
-    } = windowHandler || {
-        modal: false,
-        rawModal: false,
-        selected: [],
-        indicator: ''
-    }
-
-    const {
-        includedView
-    } = listHandler || {
-        includedView: {}
-    }
-
-    const {
-        enableTutorial,
-        processStatus,
-        me
-    } = appHandler || {
-        enableTutorial: false,
-        processStatus: '',
-        me: {}
-    }
-
-    return {
-        modal,
-        selected,
-        indicator,
-        rawModal,
-        processStatus,
-        includedView,
-        enableTutorial,
-        me
-    }
-}
-
-Dashboard = connect(mapStateToProps)(Dashboard);
-
-export default Dashboard
+export default connect(mapStateToProps)(Dashboard);

--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -14,8 +14,6 @@ import Container from '../components/Container';
 const mapStateToProps = state => ({
     modal: state.windowHandler.modal,
     rawModal: state.windowHandler.rawModal,
-    selected: state.windowHandler.selected,
-    selectedWindowType: state.windowHandler.selectedWindowType,
     latestNewDocument: state.windowHandler.latestNewDocument,
     indicator: state.windowHandler.indicator,
     includedView: state.listHandler.includedView,
@@ -39,7 +37,6 @@ class DocList extends Component {
         pathname: PropTypes.string.isRequired,
         modal: PropTypes.object.isRequired,
         rawModal: PropTypes.object.isRequired,
-        selected: PropTypes.array,
         indicator: PropTypes.string.isRequired,
         processStatus: PropTypes.string.isRequired,
     }
@@ -87,8 +84,8 @@ class DocList extends Component {
 
     render() {
         const {
-            windowType, breadcrumb, query, modal, selected, rawModal,
-            indicator, processStatus, includedView, selectedWindowType,
+            windowType, breadcrumb, query, modal, rawModal, indicator,
+            processStatus, includedView,
         } = this.props;
         const { modalTitle, notfound, modalDescription } = this.state;
         let refRowIds = [];
@@ -110,8 +107,6 @@ class DocList extends Component {
                 windowType={windowType}
                 query={query}
                 notfound={notfound}
-                selected={selected}
-                selectedWindowType={selectedWindowType}
                 indicator={indicator}
                 modalTitle={modalTitle}
                 processStatus={processStatus}
@@ -133,8 +128,6 @@ class DocList extends Component {
                         refId={query.refId}
                         refTabId={query.refTabId}
                         refRowIds={refRowIds}
-                        selectedWindowType={selectedWindowType}
-                        selected={selected}
                         includedView={includedView}
                         inBackground={rawModal.visible}
                         inModal={modal.visible}
@@ -153,8 +146,6 @@ class DocList extends Component {
                     ) && (
                         <DocumentList
                             type="includedView"
-                            selected={selected}
-                            selectedWindowType={selectedWindowType}
                             windowType={includedView.windowType}
                             defaultViewId={includedView.viewId}
                             fetchQuickActionsOnInit

--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -1,28 +1,47 @@
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {connect} from 'react-redux';
 
+import { updateUri } from '../actions/AppActions';
+import { getWindowBreadcrumb } from '../actions/MenuActions';
+import {
+    selectTableItems,
+    setLatestNewDocument,
+} from '../actions/WindowActions';
 import DocumentList from '../components/app/DocumentList';
 import Container from '../components/Container';
 
-import {
-    getWindowBreadcrumb
-} from '../actions/MenuActions';
-
-import {
-    updateUri
-} from '../actions/AppActions';
-
-import {
-    selectTableItems,
-    setLatestNewDocument
-} from '../actions/WindowActions';
+const mapStateToProps = state => ({
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    selected: state.windowHandler.selected,
+    selectedWindowType: state.windowHandler.selectedWindowType,
+    latestNewDocument: state.windowHandler.latestNewDocument,
+    indicator: state.windowHandler.indicator,
+    includedView: state.listHandler.includedView,
+    processStatus: state.appHandler.processStatus,
+    breadcrumb: state.menuHandler.breadcrumb,
+    pathname: state.routing.locationBeforeTransitions.pathname,
+});
 
 class DocList extends Component {
     state = {
         modalTitle: '',
         modalDescription: '',
         notfound: false,
+    }
+
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+        breadcrumb: PropTypes.array.isRequired,
+        query: PropTypes.object.isRequired,
+        includedView: PropTypes.object.isRequired,
+        pathname: PropTypes.string.isRequired,
+        modal: PropTypes.object.isRequired,
+        rawModal: PropTypes.object.isRequired,
+        selected: PropTypes.array,
+        indicator: PropTypes.string.isRequired,
+        processStatus: PropTypes.string.isRequired,
     }
 
     componentDidMount = () => {
@@ -41,52 +60,43 @@ class DocList extends Component {
     }
 
     componentDidUpdate = (prevProps) => {
-        const {dispatch, windowType} = this.props;
+        const { dispatch, windowType } = this.props;
 
-        if(prevProps.windowType !== windowType){
+        if (prevProps.windowType !== windowType) {
             dispatch(getWindowBreadcrumb(windowType));
         }
     }
 
     updateUriCallback = (prop, value) => {
-        const {dispatch, query, pathname} = this.props;
+        const { dispatch, query, pathname } = this.props;
+
         dispatch(updateUri(pathname, query, prop, value));
     }
 
     setModalTitle = (title) => {
-        this.setState({
-            modalTitle: title
-        })
+        this.setState({ modalTitle: title });
     }
 
     setModalDescription = (desc) => {
-        this.setState({
-            modalDescription: desc
-        })
+        this.setState({ modalDescription: desc });
     }
 
     setNotFound = (isNotFound) => {
-        this.setState({
-            notfound: isNotFound
-        })
+        this.setState({ notfound: isNotFound });
     }
 
     render() {
         const {
             windowType, breadcrumb, query, modal, selected, rawModal,
-            indicator, processStatus, includedView, selectedWindowType
+            indicator, processStatus, includedView, selectedWindowType,
         } = this.props;
-
-        const {
-            modalTitle, notfound, modalDescription
-        } = this.state;
-
+        const { modalTitle, notfound, modalDescription } = this.state;
         let refRowIds = [];
+
         if (query && query.refRowIds) {
             try {
                 refRowIds = JSON.parse(query.refRowIds);
-            }
-            catch (e) {
+            } catch (e) {
                 refRowIds = [];
             }
         }
@@ -94,9 +104,18 @@ class DocList extends Component {
         return (
             <Container
                 entity="documentView"
-                {...{modal, rawModal, breadcrumb, windowType, query, notfound,
-                    selected, selectedWindowType, indicator, modalTitle,
-                    processStatus, includedView}}
+                modal={modal}
+                rawModal={rawModal}
+                breadcrumb={breadcrumb}
+                windowType={windowType}
+                query={query}
+                notfound={notfound}
+                selected={selected}
+                selectedWindowType={selectedWindowType}
+                indicator={indicator}
+                modalTitle={modalTitle}
+                processStatus={processStatus}
+                includedView={includedView}
                 setModalTitle={this.setModalTitle}
                 setModalDescription={this.setModalDescription}
                 modalDescription={modalDescription}
@@ -119,7 +138,7 @@ class DocList extends Component {
                         includedView={includedView}
                         inBackground={rawModal.visible}
                         inModal={modal.visible}
-                        fetchQuickActionsOnInit={true}
+                        fetchQuickActionsOnInit
                         processStatus={processStatus}
                         disablePaginationShortcuts={
                             modal.visible || rawModal.visible
@@ -138,9 +157,9 @@ class DocList extends Component {
                             selectedWindowType={selectedWindowType}
                             windowType={includedView.windowType}
                             defaultViewId={includedView.viewId}
-                            fetchQuickActionsOnInit={true}
+                            fetchQuickActionsOnInit
                             processStatus={processStatus}
-                            isIncluded={true}
+                            isIncluded
                             inBackground={false}
                             inModal={false}
                         />
@@ -151,70 +170,4 @@ class DocList extends Component {
     }
 }
 
-DocList.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    breadcrumb: PropTypes.array.isRequired,
-    query: PropTypes.object.isRequired,
-    includedView: PropTypes.object.isRequired,
-    pathname: PropTypes.string.isRequired,
-    modal: PropTypes.object.isRequired,
-    rawModal: PropTypes.object.isRequired,
-    selected: PropTypes.array,
-    indicator: PropTypes.string.isRequired,
-    processStatus: PropTypes.string.isRequired
-}
-
-function mapStateToProps(state) {
-    const {
-        windowHandler, menuHandler, listHandler, appHandler, routing
-    } = state;
-
-    const {
-        modal,
-        rawModal,
-        selected,
-        selectedWindowType,
-        latestNewDocument,
-        indicator
-    } = windowHandler || {
-        modal: false,
-        rawModal: false,
-        selected: [],
-        selectedWindowType: null,
-        latestNewDocument: null,
-        indicator: ''
-    }
-
-    const {
-        includedView
-    } = listHandler || {
-        includedView: {}
-    }
-
-    const {
-        processStatus
-    } = appHandler || {
-        processStatus: ''
-    }
-
-    const {
-        breadcrumb
-    } = menuHandler || {
-        breadcrumb: []
-    }
-
-    const {
-        pathname
-    } = routing.locationBeforeTransitions || {
-        pathname: ''
-    }
-
-    return {
-        modal, breadcrumb, pathname, selected, indicator, includedView,
-        latestNewDocument, rawModal, processStatus, selectedWindowType
-    }
-}
-
-DocList = connect(mapStateToProps)(DocList)
-
-export default DocList;
+export default connect(mapStateToProps)(DocList);

--- a/src/containers/DocList.js
+++ b/src/containers/DocList.js
@@ -19,22 +19,23 @@ import {
 } from '../actions/WindowActions';
 
 class DocList extends Component {
-    constructor(props){
-        super(props);
-
-        this.state = {
-            modalTitle: '',
-            modalDescription: '',
-            notfound: false
-        }
+    state = {
+        modalTitle: '',
+        modalDescription: '',
+        notfound: false,
     }
 
     componentDidMount = () => {
-        const {dispatch, windowType, latestNewDocument} = this.props;
+        const { dispatch, windowType, latestNewDocument, query } = this.props;
+
         dispatch(getWindowBreadcrumb(windowType));
 
-        if(latestNewDocument){
-            dispatch(selectTableItems([latestNewDocument], windowType));
+        if (latestNewDocument) {
+            dispatch(selectTableItems({
+                windowType,
+                viewId: query.viewId,
+                ids: [latestNewDocument],
+            }));
             dispatch(setLatestNewDocument(null));
         }
     }

--- a/src/containers/InboxAll.js
+++ b/src/containers/InboxAll.js
@@ -1,72 +1,49 @@
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {connect} from 'react-redux';
 
 import Container from '../components/Container';
-
 import Inbox from '../components/inbox/Inbox';
 
+const mapStateToProps = state => ({
+    inbox: state.appHandler.inbox,
+    processStatus: state.appHandler.processStatus,
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    selected: state.windowHandler.selected,
+    indicator: state.windowHandler.indicator,
+    includedView: state.listHandler.includedView,
+});
+
 class InboxAll extends Component {
+    static propTypes = {
+        dispatch: PropTypes.func.isRequired,
+        inbox: PropTypes.object.isRequired,
+    }
+
     render() {
         const {
-            inbox, modal, rawModal, processStatus, indicator, selected,
-            includedView
+            inbox,
+            modal,
+            rawModal,
+            processStatus,
+            indicator,
+            includedView,
         } = this.props;
 
         return (
             <Container
-                siteName = "Inbox"
-                {...{modal, rawModal, processStatus, indicator, selected,
-                    includedView}}
+                siteName="Inbox"
+                modal={modal}
+                rawModal={rawModal}
+                processStatus={processStatus}
+                indicator={indicator}
+                includedView={includedView}
             >
-                <Inbox
-                    all={true}
-                    inbox={inbox}
-                />
+                <Inbox all inbox={inbox} />
             </Container>
         );
     }
 }
 
-function mapStateToProps(state) {
-    const { appHandler, windowHandler, listHandler  } = state;
-
-    const {
-        inbox,
-        processStatus
-    } = appHandler || {
-        inbox: {},
-        processStatus: ''
-    }
-
-    const {
-        modal,
-        rawModal,
-        selected,
-        indicator,
-    } = windowHandler || {
-        modal: false,
-        rawModal: false,
-        selected: [],
-        indicator: ''
-    }
-
-    const {
-        includedView
-    } = listHandler || {
-        includedView: {}
-    }
-
-    return {
-        inbox, modal, rawModal, selected, indicator, includedView, processStatus
-    }
-}
-
-InboxAll.propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    inbox: PropTypes.object.isRequired
-};
-
-InboxAll = connect(mapStateToProps)(InboxAll);
-
-export default InboxAll
+export default connect(mapStateToProps)(InboxAll);

--- a/src/containers/InboxAll.js
+++ b/src/containers/InboxAll.js
@@ -10,7 +10,6 @@ const mapStateToProps = state => ({
     processStatus: state.appHandler.processStatus,
     modal: state.windowHandler.modal,
     rawModal: state.windowHandler.rawModal,
-    selected: state.windowHandler.selected,
     indicator: state.windowHandler.indicator,
     includedView: state.listHandler.includedView,
 });

--- a/src/containers/MasterWindow.js
+++ b/src/containers/MasterWindow.js
@@ -1,11 +1,10 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
-import {push, replace} from 'react-router-redux';
-
 import { Steps, Hints } from 'intro.js-react';
-import { introSteps, introHints } from '../components/intro/intro';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import {connect} from 'react-redux';
+import { push } from 'react-router-redux';
 
+import { addNotification } from '../actions/AppActions';
 import {
     attachFileAction,
     clearMasterData,
@@ -14,44 +13,65 @@ import {
     sortTab,
     connectWS,
     disconnectWS,
-    fireUpdateData
+    fireUpdateData,
 } from '../actions/WindowActions';
-
-import {
-    addNotification
-} from '../actions/AppActions';
-
-import Window from '../components/Window';
+import { introSteps, introHints } from '../components/intro/intro';
 import BlankPage from '../components/BlankPage';
 import Container from '../components/Container';
+import Window from '../components/Window';
+
+const mapStateToProps = state => ({
+    master: state.windowHandler.master,
+    modal: state.windowHandler.modal,
+    rawModal: state.windowHandler.rawModal,
+    selected: state.windowHandler.selected,
+    selectedWindowType: state.windowHandler.selectedWindowType,
+    indicator: state.windowHandler.indicator,
+    includedView: state.listHandler.includedView,
+    enableTutorial: state.appHandler.enableTutorial,
+    processStatus: state.appHandler.processStatus,
+    me: state.appHandler.me,
+    breadcrumb: state.menuHandler.breadcrumb,
+});
 
 class MasterWindow extends Component {
-    constructor(props){
-        super(props);
-
-        this.state = {
-            newRow: false,
-            modalTitle: null,
-            isDeleted: false,
-            dropzoneFocused: false,
-            introEnabled: null,
-            hintsEnabled: null,
-            introSteps: null,
-            introHints: null
-        };
+    state = {
+        newRow: false,
+        modalTitle: null,
+        isDeleted: false,
+        dropzoneFocused: false,
+        introEnabled: null,
+        hintsEnabled: null,
+        introSteps: null,
+        introHints: null,
     }
 
-    componentDidMount(){
-        const {master} = this.props;
+    static contextTypes = {
+        router: PropTypes.object.isRequired,
+    }
+
+    static propTypes = {
+        modal: PropTypes.object.isRequired,
+        master: PropTypes.object.isRequired,
+        breadcrumb: PropTypes.array.isRequired,
+        dispatch: PropTypes.func.isRequired,
+        selected: PropTypes.array,
+        rawModal: PropTypes.object.isRequired,
+        indicator: PropTypes.string.isRequired,
+        me: PropTypes.object.isRequired,
+    }
+
+    componentDidMount() {
+        const { master } = this.props;
         const isDocumentNotSaved = !master.saveStatus.saved;
 
-        if(isDocumentNotSaved){
+        if (isDocumentNotSaved) {
             this.initEventListeners();
         }
     }
 
     componentDidUpdate(prevProps) {
-        const {master, modal, params, dispatch, me} = this.props;
+        const { master, modal, params, dispatch, me } = this.props;
         const isDocumentNotSaved = !master.saveStatus.saved;
         const isDocumentSaved = master.saveStatus.saved;
 
@@ -67,11 +87,15 @@ class MasterWindow extends Component {
                 docIntroSteps = [];
 
                 if (windowIntroSteps['all']) {
-                    docIntroSteps = docIntroSteps.concat(windowIntroSteps['all']);
+                    docIntroSteps = docIntroSteps.concat(
+                        windowIntroSteps['all'],
+                    );
                 }
 
                 if (master.docId && windowIntroSteps[master.docId]) {
-                    docIntroSteps = docIntroSteps.concat(windowIntroSteps[master.docId]);
+                    docIntroSteps = docIntroSteps.concat(
+                        windowIntroSteps[master.docId],
+                    );
                 }
             }
 
@@ -84,11 +108,15 @@ class MasterWindow extends Component {
                 docIntroHints = [];
 
                 if (windowIntroHints['all']) {
-                    docIntroHints = docIntroHints.concat(windowIntroHints['all']);
+                    docIntroHints = docIntroHints.concat(
+                        windowIntroHints['all'],
+                    );
                 }
 
                 if (master.docId && windowIntroHints[master.docId]) {
-                    docIntroHints = docIntroHints.concat(windowIntroHints[master.docId]);
+                    docIntroHints = docIntroHints.concat(
+                        windowIntroHints[master.docId],
+                    );
                 }
             }
 
@@ -96,44 +124,58 @@ class MasterWindow extends Component {
                 introEnabled: (docIntroSteps && (docIntroSteps.length > 0)),
                 hintsEnabled: (docIntroHints && (docIntroHints.length > 0)),
                 introSteps: docIntroSteps,
-                introHints: docIntroHints
+                introHints: docIntroHints,
             });
         }
 
-        if(prevProps.master.websocket !== master.websocket && master.websocket){
+        if (prevProps.master.websocket !== master.websocket &&
+            master.websocket
+        ) {
             connectWS.call(this, master.websocket, msg => {
-                const {includedTabsInfo, stale} = msg;
-                const {master} = this.props;
+                const { includedTabsInfo, stale } = msg;
+                const { master } = this.props;
 
-                if(stale){
-                    dispatch(
-                        fireUpdateData('window', params.windowType, params.docId, null, null, null, null )
-                    );
-                    
+                if (stale) {
+                    dispatch(fireUpdateData(
+                        'window',
+                        params.windowType,
+                        params.docId,
+                        null,
+                        null,
+                        null,
+                        null,
+                    ));
                 }
 
-                includedTabsInfo && Object.keys(includedTabsInfo).map(tabId => {
-                    const tabLayout = master.layout.tabs && master.layout.tabs.filter(tab =>
-                        tab.tabId === tabId
-                    )[0];
-                    if(
-                        tabLayout && tabLayout.queryOnActivate &&
-                        master.layout.activeTab !== tabId
-                    ){
-                        return;
-                    }
-                    includedTabsInfo[tabId] &&
-                        getTab(tabId, params.windowType, master.docId)
-                            .then(tab => {
-                                dispatch(
-                                    addRowData({[tabId]: tab}, 'master')
-                                );
-                            });
-                })
+                if (includedTabsInfo) {
+                    Object.keys(includedTabsInfo).forEach(tabId => {
+                        const tabLayout = master.layout.tabs && (
+                            master.layout.tabs.filter(
+                                tab => tab.tabId === tabId,
+                            )[0]
+                        );
+                        if (tabLayout && tabLayout.queryOnActivate &&
+                            master.layout.activeTab !== tabId
+                        ) {
+                            return;
+                        }
+
+                        if (includedTabsInfo[tabId]) {
+                            getTab(tabId, params.windowType, master.docId).then(
+                                tab => {
+                                    dispatch(addRowData(
+                                        { [tabId]: tab },
+                                        'master',
+                                    ));
+                                },
+                            );
+                        }
+                    });
+                }
             });
         }
 
-        if(prevProps.master.saveStatus.saved && isDocumentNotSaved) {
+        if (prevProps.master.saveStatus.saved && isDocumentNotSaved) {
             this.initEventListeners();
         }
         if (!prevProps.master.saveStatus.saved && isDocumentSaved) {
@@ -141,30 +183,30 @@ class MasterWindow extends Component {
         }
 
         // When closing modal, we need to update the stale tabs
-        if(!modal.visible && modal.visible !== prevProps.modal.visible){
-            master.includedTabsInfo &&
-                Object.keys(master.includedTabsInfo).map(tabId => {
-                    getTab(tabId, params.windowType, master.docId)
-                        .then(tab => {
-                            dispatch(addRowData({[tabId]: tab}, 'master'));
-                        });
-                })
+        if (!modal.visible && modal.visible !== prevProps.modal.visible &&
+            master.includedTabsInfo
+        ) {
+            Object.keys(master.includedTabsInfo).map(tabId => {
+                getTab(tabId, params.windowType, master.docId)
+                    .then(tab => {
+                        dispatch(addRowData({[tabId]: tab}, 'master'));
+                    });
+            })
         }
     }
 
     componentWillUnmount() {
-        const { master, dispatch } = this.props;
+        const { master, dispatch, location: { pathname } } = this.props;
         const { isDeleted } = this.state;
-        const {pathname} = this.props.location;
         const isDocumentNotSaved =
             !master.saveStatus.saved && master.saveStatus.saved !== undefined;
 
         this.removeEventListeners();
 
-        if(isDocumentNotSaved && !isDeleted){
+        if (isDocumentNotSaved && !isDeleted) {
             const result = window.confirm('Do you really want to leave?');
 
-            if(!result){
+            if (!result) {
                 dispatch(push(pathname));
             }
         }
@@ -186,30 +228,29 @@ class MasterWindow extends Component {
     }
 
     closeModalCallback = (isNew) => {
-        if(isNew){
+        if (isNew) {
             this.setState({
-                    newRow: true
+                    newRow: true,
                 }, () => {
                     setTimeout(() => {
                         this.setState({
-                            newRow: false
-                        })
+                            newRow: false,
+                        });
                     }, 1000);
-                }
-            )
+                },
+            );
         }
     }
 
-    handleDropFile(files){
+    handleDropFile = (files) => {
         const file = files instanceof Array ? files[0] : files;
 
         if (!(file instanceof File)){
             return Promise.reject();
         }
 
-        const { dispatch, master } = this.props;
-        const dataId = master.data ? master.data.ID.value : -1;
-        const { type } = master.layout;
+        const { dispatch, master: { data, layout: { type }} } = this.props;
+        const dataId = data ? data.ID.value : -1;
 
         let fd = new FormData();
         fd.append('file', file);
@@ -219,15 +260,15 @@ class MasterWindow extends Component {
 
     handleDragStart = () => {
         this.setState({
-            dropzoneFocused: true
+            dropzoneFocused: true,
         }, () => {
             this.setState({
-                dropzoneFocused: false
-            })
-        })
+                dropzoneFocused: false,
+            });
+        });
     }
 
-    handleRejectDropped(droppedFiles){
+    handleRejectDropped = (droppedFiles) => {
         const { dispatch } = this.props;
 
         const dropped = droppedFiles instanceof Array ?
@@ -237,24 +278,19 @@ class MasterWindow extends Component {
             'Attachment', 'Dropped item [' +
             dropped.type +
             '] could not be attached', 5000, 'error'
-        ))
+        ));
     }
 
     setModalTitle = (title) => {
-        this.setState({
-            modalTitle: title
-        })
+        this.setState({ modalTitle: title });
     }
 
     handleDeletedStatus = (param) => {
-        this.setState({
-            isDeleted: param
-        })
+        this.setState({ isDeleted: param });
     }
 
     sort = (asc, field, startPage, page, tabId) => {
-        const {dispatch, master} = this.props;
-        const {windowType} = this.props.params;
+        const { dispatch, master, params: { windowType } } = this.props;
         const orderBy = (asc ? '+' : '-') + field;
         const dataId = master.docId;
 
@@ -265,66 +301,74 @@ class MasterWindow extends Component {
     }
 
     handleIntroExit = () => {
-        this.setState({
-            introEnabled: false
-        });
+        this.setState({ introEnabled: false });
     }
 
     render() {
         const {
             master, modal, breadcrumb, params, rawModal, selected,
-            selectedWindowType, includedView, processStatus, enableTutorial
+            selectedWindowType, includedView, processStatus, enableTutorial,
         } = this.props;
-
         const {
             dropzoneFocused, newRow, modalTitle,
-            introEnabled, hintsEnabled, introSteps, introHints
+            introEnabled, hintsEnabled, introSteps, introHints,
         } = this.state;
-
-        const {
-            docActionElement, documentSummaryElement
-        } = master.layout;
+        const { docActionElement, documentSummaryElement } = master.layout;
 
         const dataId = master.docId;
         const docNoData = master.data.DocumentNo;
         let activeTab;
         if (master.layout) {
-            activeTab = master.layout.activeTab
+            activeTab = master.layout.activeTab;
         }
 
         const docStatusData = {
-            'status': master.data.DocStatus || -1,
-            'action': master.data.DocAction || -1,
-            'displayed': true
+            status: master.data.DocStatus || -1,
+            action: master.data.DocAction || -1,
+            displayed: true,
         };
 
         const docSummaryData = documentSummaryElement &&
             master.data[documentSummaryElement.fields[0].field];
 
-        const isDocumentNotSaved = dataId !== 'notfound' &&
-        (master.saveStatus.saved !== undefined && !master.saveStatus.saved) &&
-        (master.validStatus.initialValue !== undefined) &&
-        !master.validStatus.initialValue
+        const isDocumentNotSaved = (
+            dataId !== 'notfound' &&
+            master.saveStatus.saved !== undefined &&
+            !master.saveStatus.saved &&
+            master.validStatus.initialValue !== undefined &&
+            !master.validStatus.initialValue
+        );
 
         return (
             <Container
                 entity="window"
-                {...{dropzoneFocused, docStatusData, docSummaryData, modal,
-                    dataId, breadcrumb, docNoData, isDocumentNotSaved, rawModal,
-                    selected, selectedWindowType, modalTitle, includedView,
-                    processStatus, activeTab
-                }}
+                dropzoneFocused={dropzoneFocused}
+                docStatusData={docStatusData}
+                docSummaryData={docSummaryData}
+                modal={modal}
+                dataId={dataId}
+                breadcrumb={breadcrumb}
+                docNoData={docNoData}
+                isDocumentNotSaved={isDocumentNotSaved}
+                rawModal={rawModal}
+                selected={selected}
+                selectedWindowType={selectedWindowType}
+                modalTitle={modalTitle}
+                includedView={includedView}
+                processStatus={processStatus}
+                activeTab={activeTab}
                 closeModalCallback={this.closeModalCallback}
                 setModalTitle={this.setModalTitle}
                 docActionElem = {docActionElement}
                 windowType={params.windowType}
                 docId={params.docId}
-                showSidelist={true}
+                showSidelist
                 showIndicator={!modal.visible}
                 handleDeletedStatus={this.handleDeletedStatus}
             >
-                {dataId === 'notfound' ?
-                    <BlankPage what="Document" /> :
+                {dataId === 'notfound' ? (
+                    <BlankPage what="Document" />
+                ) : (
                     <Window
                         key="window"
                         data={master.data}
@@ -336,15 +380,12 @@ class MasterWindow extends Component {
                         isModal={false}
                         newRow={newRow}
                         handleDragStart={this.handleDragStart}
-                        handleDropFile={accepted =>
-                            this.handleDropFile(accepted)}
-                        handleRejectDropped={
-                            rejected => this.handleRejectDropped(rejected)
-                        }
+                        handleDropFile={this.handleDropFile}
+                        handleRejectDropped={this.handleRejectDropped}
                     />
-                }
+                )}
 
-                { (enableTutorial && introSteps && (introSteps.length > 0)) && (
+                {(enableTutorial && introSteps && (introSteps.length > 0)) && (
                     <Steps
                         enabled={introEnabled}
                         steps={introSteps}
@@ -353,7 +394,7 @@ class MasterWindow extends Component {
                     />
                 )}
 
-                { (enableTutorial && introHints && (introHints.length > 0)) && (
+                {(enableTutorial && introHints && (introHints.length > 0)) && (
                     <Hints
                         enabled={hintsEnabled}
                         hints={introHints}
@@ -364,76 +405,4 @@ class MasterWindow extends Component {
     }
 }
 
-MasterWindow.propTypes = {
-    modal: PropTypes.object.isRequired,
-    master: PropTypes.object.isRequired,
-    breadcrumb: PropTypes.array.isRequired,
-    dispatch: PropTypes.func.isRequired,
-    selected: PropTypes.array,
-    rawModal: PropTypes.object.isRequired,
-    indicator: PropTypes.string.isRequired,
-    me: PropTypes.object.isRequired
-};
-
-function mapStateToProps(state) {
-    const { windowHandler, menuHandler, listHandler, appHandler } = state;
-    const {
-        master,
-        modal,
-        rawModal,
-        selected,
-        selectedWindowType,
-        indicator
-    } = windowHandler || {
-        master: {},
-        modal: false,
-        rawModal: {},
-        selected: [],
-        selectedWindowType: null,
-        indicator: ''
-    }
-
-    const {
-        includedView
-    } = listHandler || {
-        includedView: {}
-    }
-
-    const {
-        enableTutorial,
-        processStatus,
-        me
-    } = appHandler || {
-        enableTutorial: false,
-        processStatus: '',
-        me: {}
-    }
-
-    const {
-        breadcrumb
-    } = menuHandler || {
-        breadcrumb: []
-    }
-
-    return {
-        master,
-        breadcrumb,
-        modal,
-        selected,
-        rawModal,
-        indicator,
-        selectedWindowType,
-        includedView,
-        processStatus,
-        enableTutorial,
-        me
-    }
-}
-
-MasterWindow.contextTypes = {
-    router: PropTypes.object.isRequired
-}
-
-MasterWindow = connect(mapStateToProps)(MasterWindow)
-
-export default MasterWindow;
+export default connect(mapStateToProps)(MasterWindow)

--- a/src/containers/MasterWindow.js
+++ b/src/containers/MasterWindow.js
@@ -24,8 +24,6 @@ const mapStateToProps = state => ({
     master: state.windowHandler.master,
     modal: state.windowHandler.modal,
     rawModal: state.windowHandler.rawModal,
-    selected: state.windowHandler.selected,
-    selectedWindowType: state.windowHandler.selectedWindowType,
     indicator: state.windowHandler.indicator,
     includedView: state.listHandler.includedView,
     enableTutorial: state.appHandler.enableTutorial,
@@ -55,7 +53,6 @@ class MasterWindow extends Component {
         master: PropTypes.object.isRequired,
         breadcrumb: PropTypes.array.isRequired,
         dispatch: PropTypes.func.isRequired,
-        selected: PropTypes.array,
         rawModal: PropTypes.object.isRequired,
         indicator: PropTypes.string.isRequired,
         me: PropTypes.object.isRequired,
@@ -306,8 +303,8 @@ class MasterWindow extends Component {
 
     render() {
         const {
-            master, modal, breadcrumb, params, rawModal, selected,
-            selectedWindowType, includedView, processStatus, enableTutorial,
+            master, modal, breadcrumb, params, rawModal, includedView,
+            processStatus, enableTutorial,
         } = this.props;
         const {
             dropzoneFocused, newRow, modalTitle,
@@ -351,8 +348,6 @@ class MasterWindow extends Component {
                 docNoData={docNoData}
                 isDocumentNotSaved={isDocumentNotSaved}
                 rawModal={rawModal}
-                selected={selected}
-                selectedWindowType={selectedWindowType}
                 modalTitle={modalTitle}
                 includedView={includedView}
                 processStatus={processStatus}

--- a/src/reducers/windowHandler.js
+++ b/src/reducers/windowHandler.js
@@ -44,6 +44,15 @@ const initialState = {
     selections: {},
 };
 
+export const NO_SELECTION = [];
+export const getSelection = ({ state, windowType, viewId }) => {
+    const windowTypeSelections = state.windowHandler.selections[windowType];
+
+    return (
+        windowTypeSelections && windowTypeSelections[viewId]
+    ) || NO_SELECTION;
+};
+
 export default function windowHandler(state = initialState, action) {
 
     switch(action.type){

--- a/src/reducers/windowHandler.js
+++ b/src/reducers/windowHandler.js
@@ -41,7 +41,7 @@ const initialState = {
     latestNewDocument: null,
     viewId: null,
     selected: [],
-    selectedWindowType: null
+    selections: {},
 };
 
 export default function windowHandler(state = initialState, action) {
@@ -356,11 +356,23 @@ export default function windowHandler(state = initialState, action) {
 
         // END OF INDICATOR ACTIONS
 
-        case types.SELECT_TABLE_ITEMS:
-            return Object.assign({}, state, {
-                selected: action.ids,
-                selectedWindowType: action.windowType
-            });
+        case types.SELECT_TABLE_ITEMS: {
+            const { windowType, viewId, ids } = action.payload;
+
+            return {
+                ...state,
+
+                selections: {
+                    ...state.selections,
+
+                    [windowType]: {
+                        ...state.selections[windowType],
+
+                        [viewId]: ids,
+                    },
+                },
+            };
+        }
 
         // LATEST NEW DOCUMENT CACHE
         case types.SET_LATEST_NEW_DOCUMENT:


### PR DESCRIPTION
(See #1248)

There was a lot of refactoring needed to reduce the complexity of the gist of this PR: a49cbf8d11878b885d74a1e833c5e4865b51d6b8

Now there is one global `state.windowHandler.selected` and `selectedWindowType` attribute shared across all windows. `DocumentList` caches the selection to avoid losing selection:
https://github.com/metasfresh/metasfresh-webui-frontend/blob/25ecf1f3c0716c7312c47e63ee6c16d51157c021/src/components/app/DocumentList.js#L158-L185

With this PR, this part will be removed. Instead `selections` for each `windowType` and `viewId` are stored, meaning selections can be re-used after changing view (and not being re-created in future).

Also the components `DocumentList`, `Modal` and `SubHeader` will retrieve `selected` items based on their `viewId` and `windowType` props.