### PR TITLE
Implement "DateRange" widget

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -309,6 +309,25 @@ class RawWidget extends Component {
                         </div>
                     )
                 }
+            case 'DateRange': {
+                return (
+                    <DatetimeRange
+                        onChange={(value, valueTo) => (
+                            this.handlePatch(widgetField, {
+                                ...(value && { value }),
+                                ...(valueTo && { valueTo })
+                            })
+                        )}
+                        mandatory={widgetData[0].mandatory}
+                        validStatus={widgetData[0].validStatus}
+                        onShow={onShow}
+                        onHide={onHide}
+                        value={widgetData[0].value}
+                        valueTo={widgetData[0].valueTo}
+                        tabIndex={fullScreen ? -1 : tabIndex}
+                     />
+                );
+            }
             case 'Time':
                 return (
                     <div className={this.getClassNames({ icon: true })}>


### PR DESCRIPTION
#981 

Can someone explain the difference between those cases and where exactly they are used within the system?


Edit: for more context
```js
switch (widgetType)
```
/Edit

```js
case 'Date' && range
```

```js
case 'DateTime' && range
```

```js
case 'DateRange'
```

---

See the redundancy which I would like to resolve:

https://github.com/metasfresh/metasfresh-webui-frontend/blob/89198c89f87d7f0c7c3bd76bbb8d4086a7a3fa9c/src/components/widget/RawWidget.js#L202-L228

https://github.com/metasfresh/metasfresh-webui-frontend/blob/89198c89f87d7f0c7c3bd76bbb8d4086a7a3fa9c/src/components/widget/RawWidget.js#L257-L284

https://github.com/metasfresh/metasfresh-webui-frontend/blob/89198c89f87d7f0c7c3bd76bbb8d4086a7a3fa9c/src/components/widget/RawWidget.js#L312-L329