### PR TITLE
Re-fetch layout if language is changed

### DIFF
--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -429,6 +429,9 @@ export function initWindow(windowType, docId, tabId, rowId = null, isAdvanced) {
     }
 }
 
+const LANGUAGE_ENTITY = 'window',
+    LANGUAGE_WINDOW_TYPE = 53100,
+    LANGUAGE_PROPERTY = 'AD_Language';
 /*
  *  Wrapper for patch request of widget elements
  *  when responses should merge store
@@ -454,7 +457,29 @@ export function patch(
                 response.data, isModal, rowId, id, windowType, isAdvanced
             ));
 
-            dispatch(indicatorState('saved'));
+            // reinitialize layout if language is changed
+            if (entity === LANGUAGE_ENTITY &&
+                parseInt(windowType) === LANGUAGE_WINDOW_TYPE &&
+                property === LANGUAGE_PROPERTY
+            ) {
+                initLayout(
+                    'window', windowType, tabId, null, null, isAdvanced
+                ).then(response =>
+                    dispatch(initLayoutSuccess(
+                        response.data, getScope(isModal)
+                    ))
+                ).then(response => {
+                    if (!isModal) {
+                        dispatch(initTabs(
+                            response.layout.tabs, windowType, id, isModal
+                        ))
+                    }
+
+                    dispatch(indicatorState('saved'));
+                })
+            } else {
+                dispatch(indicatorState('saved'));
+            }
 
             return response.data;
         }).catch(() => {


### PR DESCRIPTION
(See #1280)

**NOTE:** This fix uses hardcoded values. A solution to this is mentioned here: https://github.com/metasfresh/metasfresh-webui-frontend/issues/1280#issuecomment-342010578