### PR TITLE
#1389 Adjusted the shortcut for advanced edit in main grid view

### DIFF
--- a/src/shortcuts/keymap.js
+++ b/src/shortcuts/keymap.js
@@ -24,7 +24,7 @@ export default {
     /* Document list context */
     OPEN_SELECTED: `${mod}+B`, // Open document in new tab
     REMOVE_SELECTED: `${mod}+Y`,
-    ADVANCED_EDIT: `${mod}+A`,
+    ADVANCED_EDIT: `${mod}+E`,
 
     /* POS context */
     SELECT_ALL_LEAFS: `${mod}+S`,


### PR DESCRIPTION
Adjusted the shortcut for advanced edit in main grid view from [alt]+A
to [alt]+E

https://github.com/metasfresh/metasfresh-webui-frontend/issues/1389