### PR TITLE
Prevent auto-focusing additional properties in lookup

### DIFF
--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -248,7 +248,8 @@ class Lookup extends Component {
                 <RawLookup
                   key={index}
                   defaultValue={itemByProperty.value}
-                  initialFocus={index === 0 ? initialFocus : false}
+                  autoFocus={index === 0 && autoFocus}
+                  initialFocus={index === 0 && initialFocus}
                   mainProperty={[item]}
                   resetLocalClearing={this.resetLocalClearing}
                   setNextProperty={this.setNextProperty}
@@ -279,7 +280,6 @@ class Lookup extends Component {
                     viewId,
                     subentity,
                     subentityId,
-                    autoFocus,
                     tabId,
                     rowId,
                     newRecordCaption,


### PR DESCRIPTION
(See #1451)

Issue was introduced by https://github.com/metasfresh/metasfresh-webui-frontend/issues/1433, reverting https://github.com/metasfresh/metasfresh-webui-frontend/commit/86d35b241a146805529ec33059db6f4758b637bc resolves this issue as well but probably breaks #1433 again