### PR TITLE
#1478 Attachment in eMail Editor: Show File name/ caption instead of key

### DIFF
--- a/src/assets/css/email.css
+++ b/src/assets/css/email.css
@@ -164,7 +164,7 @@
     margin-bottom: 10px;
 }
 
-.attachnemt-text {
+.attachment-text {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/src/components/email/Attachments.js
+++ b/src/components/email/Attachments.js
@@ -36,7 +36,8 @@ class Attachments extends Component {
             return (
               <div className="attachment" key={index}>
                 <div className="attachment-text">
-                  {item[Object.keys(item)[0]]}
+                  //{item[Object.keys(item)[0]]}
+                  {item.caption}
                 </div>
                 <div className="input-icon input-icon-lg">
                   {/*<i className="meta-icon-close-1"/>*/}

--- a/src/components/email/Attachments.js
+++ b/src/components/email/Attachments.js
@@ -36,7 +36,7 @@ class Attachments extends Component {
             return (
               <div className="attachment" key={index}>
                 <div className="attachment-text">
-                  //{item[Object.keys(item)[0]]}
+                  {/*{item[Object.keys(item)[0]]}*/}
                   {item.caption}
                 </div>
                 <div className="input-icon input-icon-lg">

--- a/src/components/email/Attachments.js
+++ b/src/components/email/Attachments.js
@@ -35,7 +35,7 @@ class Attachments extends Component {
           attachments.map((item, index) => {
             return (
               <div className="attachment" key={index}>
-                <div className="attachnemt-text">
+                <div className="attachment-text">
                   {item[Object.keys(item)[0]]}
                 </div>
                 <div className="input-icon input-icon-lg">


### PR DESCRIPTION
Improving the added Attachments in eMail editor. Now showing the Name/ Caption of Attachment instead of the Attachment key. Further typos fixes in eMail editor and email.css.

https://github.com/metasfresh/metasfresh-webui-frontend/issues/1478