### PR TITLE
#1481 Cannot open "Create purchase orders" modal view

### DIFF
--- a/src/components/app/Modal.js
+++ b/src/components/app/Modal.js
@@ -165,7 +165,11 @@ class Modal extends Component {
             processType: windowType,
             viewId: modalViewId,
             type: parentType,
-            ids: modalViewDocumentIds || (dataId ? [dataId] : parentSelection),
+            //ids: modalViewDocumentIds || (dataId ? [dataId] : parentSelection),
+            ids: modalViewId
+              ? modalViewDocumentIds
+              : dataId ? [dataId] : parentSelection,
+            //ids: (dataId ? [dataId] : modalViewDocumentIds) || parentSelection,
             tabId,
             rowId
           };

--- a/src/components/app/Modal.js
+++ b/src/components/app/Modal.js
@@ -165,11 +165,9 @@ class Modal extends Component {
             processType: windowType,
             viewId: modalViewId,
             type: parentType,
-            //ids: modalViewDocumentIds || (dataId ? [dataId] : parentSelection),
             ids: modalViewId
               ? modalViewDocumentIds
               : dataId ? [dataId] : parentSelection,
-            //ids: (dataId ? [dataId] : modalViewDocumentIds) || parentSelection,
             tabId,
             rowId
           };


### PR DESCRIPTION
Fixes the modal view for Menu actions. Now opens again for various processes.

https://github.com/metasfresh/metasfresh-webui-frontend/issues/1481