### PR TITLE
1504 - Fix date selected from the date picker widget

### DIFF
--- a/src/components/DataLayoutWrapper.js
+++ b/src/components/DataLayoutWrapper.js
@@ -24,13 +24,15 @@ class DataLayoutWrapper extends Component {
   };
 
   handleChange = (field, value) => {
-    this.setState(prevState => ({
-      data: Object.assign({}, prevState.data, {
-        [field]: Object.assign({}, prevState.data[field], {
+    this.setState({
+      data: {
+        ...this.state.data,
+        [field]: {
+          ...this.state.data[field],
           value
-        })
-      })
-    }));
+        }
+      }
+    });
   };
 
   handlePatch = (prop, value, cb) => {
@@ -79,27 +81,27 @@ class DataLayoutWrapper extends Component {
   };
 
   render() {
-    const { layout, data, dataId } = this.state;
-
+    const { layout, data } = this.state;
     const { children, className } = this.props;
+
+    // sometimes it's a number, and React complaints about wrong type
+    const dataId = this.state.dataId + "";
 
     return (
       <div className={className}>
         {// The nameing of props has a significant prefix
         // to suggest dev that these props are from wrapper
-        cloneElement(
-          children,
-          Object.assign({}, this.props, {
-            DLWrapperData: data,
-            DLWrapperDataId: dataId,
-            DLWrapperLayout: layout,
+        cloneElement(children, {
+          ...this.props,
+          DLWrapperData: data,
+          DLWrapperDataId: dataId,
+          DLWrapperLayout: layout,
 
-            DLWrapperSetData: this.setData,
-            DLWrapperSetLayout: this.setLayout,
-            DLWrapperHandleChange: this.handleChange,
-            DLWrapperHandlePatch: this.handlePatch
-          })
-        )}
+          DLWrapperSetData: this.setData,
+          DLWrapperSetLayout: this.setLayout,
+          DLWrapperHandleChange: this.handleChange,
+          DLWrapperHandlePatch: this.handlePatch
+        })}
       </div>
     );
   }

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -300,9 +300,7 @@ class RawWidget extends Component {
                   tabIndex: fullScreen ? -1 : tabIndex
                 }}
                 value={widgetValue || widgetData[0].value}
-                onChange={date => {
-                  handleChange(widgetField, date);
-                }}
+                onChange={date => handleChange(widgetField, date.utc(true))}
                 patch={date =>
                   this.handlePatch(
                     widgetField,


### PR DESCRIPTION
Looks like #1504 is caused by TZ. When selecting a date from the widget, it's using our local TZ (UTC+1). But when we're normalizing it for the backend, it's using UTC. And because time is set to midnight, we end up with an earlier date.

My change resets the date to UTC discarding the local TZ. This looks to be safe, because we're not interested in time anyway.

Another change I made in this PR is forcing `dataId` to be string as right now it's throwing errors in the console. Type must be switched somewhere between the backend and frontend. Plus some small cleanup, getting rid of `Object.assign`  in favor of spread operator.