### PR TITLE
Fix selecting items in the widget by clicking

### DIFF
--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -31,20 +31,18 @@ class TableCell extends Component {
   }
 
   handleBackdropLock = state => {
-    this.setState(
-      Object.assign({}, this.state, {
-        backdropLock: !!state
-      })
-    );
+    this.setState({
+      backdropLock: !!state
+    });
   };
 
   handleClickOutside = e => {
-    const { onClickOutside } = this.props;
+    const { onClickOutside, isEdited } = this.props;
     const { backdropLock } = this.state;
 
     //We can handle click outside only if
     //nested elements has no click oustide listening pending
-    if (!backdropLock) {
+    if (!backdropLock && !isEdited) {
       //it is important to change focus before collapsing to
       //blur Widget field and patch data
       this.cell && this.cell.focus();
@@ -149,7 +147,6 @@ class TableCell extends Component {
       isEdited,
       widgetData,
       item,
-      docId,
       type,
       rowId,
       tabId,
@@ -169,7 +166,7 @@ class TableCell extends Component {
       onCellChange,
       viewId
     } = this.props;
-
+    const docId = this.props.docId + "";
     const tdValue = !isEdited
       ? TableCell.fieldValueToString(
           widgetData[0].value,
@@ -178,6 +175,7 @@ class TableCell extends Component {
         )
       : null;
     const isOpenDatePicker = isEdited && item.widgetType === "Date";
+
     return (
       <td
         tabIndex={tabIndex}

--- a/src/components/widget/MasterWidget.js
+++ b/src/components/widget/MasterWidget.js
@@ -251,6 +251,7 @@ class MasterWidget extends Component {
     } = this.props;
 
     const { updated, data } = this.state;
+    const handleFocusFn = handleBackdropLock ? handleBackdropLock : () => {};
 
     return (
       <RawWidget
@@ -286,6 +287,8 @@ class MasterWidget extends Component {
           onBlurWidget,
           isOpenDatePicker
         }}
+        handleFocus={() => handleFocusFn(true)}
+        handleBlur={() => handleFocusFn(false)}
         handlePatch={this.handlePatch}
         handleChange={this.handleChange}
         handleProcess={this.handleProcess}


### PR DESCRIPTION
The event listener responsible for hiding elements when clicking outside of their body was too greedy preventing the `MasterWidget` to get the mouse event. So I've rewritten the rules and now the widget itself has control over backdropLock value. Clicking outside of it will still close it, but selection now works.

Fixes #1514 