### PR TITLE
Fix List and Lookup dropdown mouse event handlers

### DIFF
--- a/src/components/widget/Attributes/Attributes.js
+++ b/src/components/widget/Attributes/Attributes.js
@@ -40,19 +40,21 @@ class Attributes extends Component {
       property: prop,
       value
     }).then(response => {
-      const fields = response.data[0].fieldsByName;
-      Object.keys(fields).map(fieldName => {
-        this.setState(
-          prevState => ({
-            data: Object.assign({}, prevState.data, {
-              [fieldName]: Object.assign({}, prevState.data[fieldName], {
-                value
+      if (response.data && response.data.length) {
+        const fields = response.data[0].fieldsByName;
+        Object.keys(fields).map(fieldName => {
+          this.setState(
+            prevState => ({
+              data: Object.assign({}, prevState.data, {
+                [fieldName]: Object.assign({}, prevState.data[fieldName], {
+                  value
+                })
               })
-            })
-          }),
-          () => cb && cb()
-        );
-      });
+            }),
+            () => cb && cb()
+          );
+        });
+      }
     });
   };
 
@@ -125,9 +127,7 @@ class Attributes extends Component {
   };
 
   handleCompletion = () => {
-    const { attributeType, patch } = this.props;
     const { data } = this.state;
-    const attrId = data && data.ID ? data.ID.value : -1;
 
     const mandatory = Object.keys(data).filter(
       fieldName => data[fieldName].mandatory
@@ -142,9 +142,17 @@ class Attributes extends Component {
       return;
     }
 
+    this.doCompleteRequest();
+    this.handleToggle(false);
+  };
+
+  doCompleteRequest = () => {
+    const { attributeType, patch } = this.props;
+    const { data } = this.state;
+    const attrId = data && data.ID ? data.ID.value : -1;
+
     completeRequest(attributeType, attrId).then(response => {
       patch(response.data);
-      this.handleToggle(false);
     });
   };
 
@@ -209,7 +217,8 @@ class Attributes extends Component {
 }
 
 Attributes.propTypes = {
-  dispatch: PropTypes.func.isRequired
+  dispatch: PropTypes.func.isRequired,
+  patch: PropTypes.func
 };
 
 export default connect()(Attributes);

--- a/src/components/widget/Attributes/Attributes.js
+++ b/src/components/widget/Attributes/Attributes.js
@@ -128,7 +128,6 @@ class Attributes extends Component {
 
   handleCompletion = () => {
     const { data } = this.state;
-
     const mandatory = Object.keys(data).filter(
       fieldName => data[fieldName].mandatory
     );

--- a/src/components/widget/Attributes/AttributesDropdown.js
+++ b/src/components/widget/Attributes/AttributesDropdown.js
@@ -19,6 +19,10 @@ class AttributesDropdown extends Component {
     const { onClickOutside } = this.props;
     const { focused } = this.state;
 
+    if (focused) {
+      return;
+    }
+
     //we need to blur all fields, to patch them before completion
     this.dropdown.focus();
 

--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -100,9 +100,13 @@ class List extends Component {
   };
 
   handleFocus = () => {
+    const { onFocus } = this.props;
+
     if (this.state && !this.state.list && !this.state.loading) {
       this.requestListData();
     }
+
+    onFocus && onFocus();
   };
 
   focus = () => {
@@ -198,6 +202,7 @@ class List extends Component {
       lookupList,
       autofocus,
       blur,
+      onHandleBlur,
       initialFocus,
       lastProperty,
       disableAutofocus
@@ -227,6 +232,7 @@ class List extends Component {
         lastProperty={lastProperty}
         disableAutofocus={disableAutofocus}
         blur={blur}
+        onHandleBlur={onHandleBlur}
         onRequestListData={this.requestListData}
         onFocus={this.handleFocus}
         onSelect={option => this.handleSelect(option)}

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -246,7 +246,7 @@ class RawList extends Component {
   };
 
   handleBlur = e => {
-    const { dispatch } = this.props;
+    const { dispatch, onHandleBlur } = this.props;
     // if dropdown item is selected
     // prevent blur event to keep the dropdown list displayed
     if (!this.considerBlur || (e && this.dropdown.contains(e.target))) {
@@ -270,6 +270,8 @@ class RawList extends Component {
       isOpen: false,
       selected: selected || 0
     });
+
+    onHandleBlur && onHandleBlur();
 
     dispatch(allowOutsideClick());
   };

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -22,7 +22,8 @@ class Lookup extends Component {
       initialFocus: false,
       localClearing: false,
       fireDropdownList: false,
-      autofocusDisabled: false
+      autofocusDisabled: false,
+      isDropdownListOpen: false
     };
   }
 
@@ -116,6 +117,20 @@ class Lookup extends Component {
     );
   };
 
+  dropdownListToggle = value => {
+    const { onFocus, onHandleBlur } = this.props;
+
+    this.setState({
+      isDropdownListOpen: value
+    });
+
+    if (value && onFocus) {
+      onFocus();
+    } else if (!value && onHandleBlur) {
+      onHandleBlur();
+    }
+  };
+
   resetLocalClearing = () => {
     this.setState({
       localClearing: false
@@ -123,17 +138,19 @@ class Lookup extends Component {
   };
 
   handleClickOutside = () => {
-    this.setState(
-      {
-        fireClickOutside: true,
-        property: ""
-      },
-      () => {
-        this.setState({
-          fireClickOutside: false
-        });
-      }
-    );
+    if (this.state.isDropdownListOpen) {
+      this.setState(
+        {
+          fireClickOutside: true,
+          property: ""
+        },
+        () => {
+          this.setState({
+            fireClickOutside: false
+          });
+        }
+      );
+    }
   };
 
   handleInputEmptyStatus = isEmpty => {
@@ -257,6 +274,9 @@ class Lookup extends Component {
                   fireDropdownList={fireDropdownList}
                   handleInputEmptyStatus={this.handleInputEmptyStatus}
                   enableAutofocus={this.enableAutofocus}
+                  onHandleBlur={this.props.onHandleBlur}
+                  isOpen={this.state.isDropdownListOpen}
+                  onDropdownListToggle={this.dropdownListToggle}
                   {...{
                     placeholder,
                     readonly,
@@ -324,6 +344,8 @@ class Lookup extends Component {
                     setNextProperty={this.setNextProperty}
                     disableAutofocus={this.disableAutofocus}
                     enableAutofocus={this.enableAutofocus}
+                    onFocus={this.props.onFocus}
+                    onHandleBlur={this.props.onHandleBlur}
                     {...{
                       dataId,
                       entity,

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -24,7 +24,6 @@ class RawLookup extends Component {
       selected: null,
       loading: false,
       oldValue: "",
-      isOpen: false,
       shouldBeFocused: true,
       validLocal: true
     };
@@ -108,15 +107,15 @@ class RawLookup extends Component {
     // eslint-disable-next-line react/no-find-dom-node
     let element = ReactDOM.findDOMNode(this.lookupList);
     const { top } = element.getBoundingClientRect();
-    const { filter } = this.props;
-    const { isOpen } = this.state;
+    const { filter, isOpen } = this.props;
+
     if (
       isOpen &&
       filter.visible &&
       (top + 20 > filter.boundingRect.bottom ||
         top - 20 < filter.boundingRect.top)
     ) {
-      this.setState({ isOpen: false });
+      this.props.onDropdownListToggle(false);
     }
   };
 
@@ -236,17 +235,12 @@ class RawLookup extends Component {
   };
 
   handleBlur = callback => {
-    const { dispatch } = this.props;
-    this.setState(
-      {
-        isOpen: false
-      },
-      () => {
-        if (callback) {
-          callback();
-        }
-      }
-    );
+    const { dispatch, onHandleBlur } = this.props;
+
+    this.props.onDropdownListToggle(false);
+    callback && callback();
+
+    onHandleBlur && onHandleBlur();
     dispatch(allowOutsideClick());
   };
 
@@ -279,9 +273,10 @@ class RawLookup extends Component {
       this.setState({
         isInputEmpty: false,
         loading: true,
-        query: this.inputSearch.value,
-        isOpen: true
+        query: this.inputSearch.value
       });
+
+      this.props.onDropdownListToggle(true);
 
       let typeaheadRequest;
       if (entity === "documentView" && !filterWidget) {
@@ -418,10 +413,11 @@ class RawLookup extends Component {
       placeholder,
       readonly,
       disabled,
-      tabIndex
+      tabIndex,
+      isOpen
     } = this.props;
 
-    const { isInputEmpty, list, query, loading, selected, isOpen } = this.state;
+    const { isInputEmpty, list, query, loading, selected } = this.state;
     const SEARCH_ICON_WIDTH = 38;
     return (
       <div

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -50,9 +50,13 @@ class RawWidget extends Component {
   }
 
   focus = () => {
+    const { handleFocus } = this.props;
+
     if (this.rawWidget && this.rawWidget.focus) {
       this.rawWidget.focus();
     }
+
+    handleFocus && handleFocus();
   };
 
   handleFocus = e => {
@@ -66,6 +70,22 @@ class RawWidget extends Component {
     });
     listenOnKeysFalse && listenOnKeysFalse();
     handleFocus && handleFocus();
+  };
+
+  handleBlur = (widgetField, value, id) => {
+    const { dispatch, handleBlur, listenOnKeysTrue } = this.props;
+
+    dispatch(allowShortcut());
+
+    handleBlur && handleBlur(this.willPatch(value));
+
+    this.setState({
+      isEdited: false
+    });
+
+    listenOnKeysTrue && listenOnKeysTrue();
+
+    this.handlePatch(widgetField, value, id);
   };
 
   willPatch = (value, valueTo) => {
@@ -108,22 +128,6 @@ class RawWidget extends Component {
     }
 
     return null;
-  };
-
-  handleBlur = (widgetField, value, id) => {
-    const { dispatch, handleBlur, listenOnKeysTrue } = this.props;
-
-    dispatch(allowShortcut());
-
-    handleBlur && handleBlur(this.willPatch(value));
-
-    this.setState({
-      isEdited: false
-    });
-
-    listenOnKeysTrue && listenOnKeysTrue();
-
-    this.handlePatch(widgetField, value, id);
   };
 
   handleProcess = () => {
@@ -454,6 +458,8 @@ class RawWidget extends Component {
             listenOnKeys={listenOnKeys}
             listenOnKeysFalse={listenOnKeysFalse}
             closeTableField={closeTableField}
+            onFocus={this.focus}
+            onHandleBlur={this.handleBlur}
             onChange={this.handlePatch}
             onBlurWidget={onBlurWidget}
           />
@@ -476,6 +482,8 @@ class RawWidget extends Component {
             windowType={windowType}
             rowId={rowId}
             tabId={tabId}
+            onFocus={this.focus}
+            onHandleBlur={this.handleBlur}
             onChange={option => this.handlePatch(widgetField, option, id)}
             align={gridAlign}
             updated={updated}


### PR DESCRIPTION
This is a fix for #1536 and #1552 together in separate commits since they're very similar and happening in the same components.

Widget for changing attributes now allows multiple changes, and saves them after clicking outside of the widget. #1536

Lookup dropdown allows selecting option with mouse. #1552