### PR TITLE
Hide Lookup dropdown when adding new element

### DIFF
--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -218,6 +218,8 @@ class RawLookup extends Component {
       mainProperty
     } = this.props;
 
+    this.handleBlur();
+
     dispatch(
       openModal(
         newRecordCaption,


### PR DESCRIPTION
When `Add new` is selected from the Lookup dropdown we want to blur the element and hide it.