### PR TITLE
Allow updating fields without taking focus off

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -80,7 +80,8 @@ class RawWidget extends Component {
     handleBlur && handleBlur(this.willPatch(value));
 
     this.setState({
-      isEdited: false
+      isEdited: false,
+      cachedValue: undefined
     });
 
     listenOnKeysTrue && listenOnKeysTrue();
@@ -91,6 +92,7 @@ class RawWidget extends Component {
   willPatch = (value, valueTo) => {
     const { widgetData } = this.props;
     const { cachedValue } = this.state;
+
     return (
       JSON.stringify(widgetData[0].value) !== JSON.stringify(value) ||
       JSON.stringify(widgetData[0].valueTo) !== JSON.stringify(valueTo) ||
@@ -122,7 +124,7 @@ class RawWidget extends Component {
     // or cache is set and it is not equal value
     if ((isForce || this.willPatch(value, valueTo)) && handlePatch) {
       this.setState({
-        cachedValue: undefined
+        cachedValue: value
       });
       return handlePatch(property, value, id, valueTo);
     }


### PR DESCRIPTION
Atm text/number fields don't update unless user takes the focus off. This is because we're resetting the cached value on each patch, and then compare the new and current value. So I changed this to reset the cached value on blur instead, and update the stored field value after patch.

This PR is for #1564 