### PR TITLE
Get rid of babel error after compilation

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import "babel-polyfill";
 import React from 'react';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
Removes : 
```javascript
Uncaught ReferenceError: regeneratorRuntime is not defined
```

error after building. Probably caused by adding `babel-polyfill` in tests.