### PR TITLE
Fix auto focus for List inputs in modal and selecting first option on the list

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
           "singleQuote": true,
           "trailingComma": "es5",
           "bracketSpacing": true,
-          "jsxBracketSameLine": true,
+          "jsxBracketSameLine": false,
           "parser": "flow"
         }],
         "react/prop-types": "warn",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "stylelint": "^7.9.0",
     "webpack": "~1.13.0",
     "webpack-dev-server": "~1.12.1",
-    "webpack-node-externals": "^1.6.0"
+    "webpack-node-externals": "^1.6.0",
+    "why-did-you-update": "^0.1.1"
   },
   "dependencies": {
     "axios": "^0.16.2",
@@ -93,6 +94,7 @@
     "d3": "4.10.0",
     "file-loader": "~0.8.5",
     "immutability-helper": "^2.1.2",
+    "immutable": "^3.8.2",
     "intro.js": "^2.7.0",
     "intro.js-react": "^0.1.5",
     "lodash": "^4.17.4",

--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -641,6 +641,7 @@ input:checked + .input-slider:before {
     position: relative;
     cursor: pointer;
     min-width: 200px;
+    padding: .125rem .5rem;
 }
 .input-dropdown-container-static {
     position: static;
@@ -655,6 +656,17 @@ input:checked + .input-slider:before {
 }
 .input-dropdown-container:focus {
     outline-width: 0;
+}
+.input-dropdown-container.select-dropdown {
+    margin-top: .3125rem;
+    margin-bottom: .125rem;
+    border-bottom: none;   
+}
+.input-dropdown-container.select-dropdown.focused {
+    border-bottom: 1px solid #C9D5DC;
+}
+.input-dropdown-container.select-dropdown.opened {
+    border-bottom: none;
 }
 .input-dropdown-focused .input-toggled {
     border-bottom-left-radius: 0;

--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -1,19 +1,19 @@
-import PropTypes from "prop-types";
-import React, { Component } from "react";
-import { connect } from "react-redux";
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-import { dropdownRequest } from "../../../actions/GenericActions";
-import { getViewAttributeDropdown } from "../../../actions/ViewAttributesActions";
-import RawList from "./RawList";
+import { dropdownRequest } from '../../../actions/GenericActions';
+import { getViewAttributeDropdown } from '../../../actions/ViewAttributesActions';
+import RawList from './RawList';
 
 class List extends Component {
   state = {
     list: null,
     loading: false,
-    selectedItem: ""
+    selectedItem: '',
   };
 
-  previousValue = "";
+  previousValue = '';
 
   componentDidMount() {
     const { defaultValue } = this.props;
@@ -27,7 +27,7 @@ class List extends Component {
     const { isInputEmpty } = this.props;
 
     if (isInputEmpty && prevProps.isInputEmpty !== isInputEmpty) {
-      this.previousValue = "";
+      this.previousValue = '';
     }
   }
 
@@ -43,12 +43,12 @@ class List extends Component {
       subentity,
       subentityId,
       viewId,
-      attribute
+      attribute,
     } = this.props;
 
     this.setState({
       list: [],
-      loading: true
+      loading: true,
     });
 
     const propertyName = filterWidget
@@ -67,7 +67,7 @@ class List extends Component {
           tabId,
           viewId,
           propertyName,
-          rowId
+          rowId,
         });
 
     request.then(res => {
@@ -75,11 +75,11 @@ class List extends Component {
       let singleOption = values && values.length === 1;
 
       if (forceSelection && singleOption) {
-        this.previousValue = "";
+        this.previousValue = '';
 
         this.setState({
           list: values,
-          loading: false
+          loading: false,
         });
 
         let firstListValue = values[0];
@@ -89,7 +89,7 @@ class List extends Component {
       } else {
         this.setState({
           list: values,
-          loading: false
+          loading: false,
         });
       }
 
@@ -139,7 +139,7 @@ class List extends Component {
       properties,
       setNextProperty,
       mainProperty,
-      enableAutofocus
+      enableAutofocus,
     } = this.props;
 
     if (enableAutofocus) {
@@ -153,7 +153,7 @@ class List extends Component {
 
         if (option) {
           this.setState({
-            selectedItem: option
+            selectedItem: option,
           });
 
           this.previousValue = option.caption;
@@ -172,7 +172,7 @@ class List extends Component {
               let patchFields = patchResult[0].fieldsByName;
               if (patchFields.lookupValuesStale === true) {
                 this.setState({
-                  list: null
+                  list: null,
                 });
               }
             }
@@ -187,52 +187,16 @@ class List extends Component {
   };
 
   render() {
-    const {
-      rank,
-      readonly,
-      defaultValue,
-      selected,
-      align,
-      updated,
-      rowId,
-      emptyText,
-      tabIndex,
-      mandatory,
-      validStatus,
-      lookupList,
-      autoFocus,
-      blur,
-      onHandleBlur,
-      initialFocus,
-      lastProperty,
-      disableAutofocus
-    } = this.props;
-
+    const { selected, lookupList } = this.props;
     const { list, loading, selectedItem } = this.state;
 
     return (
       <RawList
+        {...this.props}
         ref={c => (this.rawList = c && c.getWrappedInstance())}
         loading={loading}
         list={list || []}
-        lookupList={lookupList}
-        rank={rank}
-        readonly={readonly}
-        defaultValue={defaultValue}
         selected={lookupList ? selectedItem : selected}
-        align={align}
-        updated={updated}
-        rowId={rowId}
-        emptyText={emptyText}
-        mandatory={mandatory}
-        validStatus={validStatus}
-        tabIndex={tabIndex}
-        autoFocus={autoFocus}
-        initialFocus={initialFocus}
-        lastProperty={lastProperty}
-        disableAutofocus={disableAutofocus}
-        blur={blur}
-        onHandleBlur={onHandleBlur}
         onRequestListData={this.requestListData}
         onFocus={this.handleFocus}
         onSelect={option => this.handleSelect(option)}
@@ -243,7 +207,7 @@ class List extends Component {
 
 List.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  autoFocus: PropTypes.bool
+  autoFocus: PropTypes.bool.isRequired,
 };
 
 export default connect(false, false, false, { withRef: true })(List);

--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -200,7 +200,7 @@ class List extends Component {
       mandatory,
       validStatus,
       lookupList,
-      autofocus,
+      autoFocus,
       blur,
       onHandleBlur,
       initialFocus,
@@ -227,7 +227,7 @@ class List extends Component {
         mandatory={mandatory}
         validStatus={validStatus}
         tabIndex={tabIndex}
-        autofocus={autofocus}
+        autoFocus={autoFocus}
         initialFocus={initialFocus}
         lastProperty={lastProperty}
         disableAutofocus={disableAutofocus}
@@ -242,7 +242,8 @@ class List extends Component {
 }
 
 List.propTypes = {
-  dispatch: PropTypes.func.isRequired
+  dispatch: PropTypes.func.isRequired,
+  autoFocus: PropTypes.bool
 };
 
 export default connect(false, false, false, { withRef: true })(List);

--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -126,8 +126,8 @@ class List extends Component {
 
     if (list && list.length > 1) {
       if (this.rawList) {
-        this.rawList.openDropdownList();
         this.rawList.focus();
+        this.rawList.openDropdownList();
       }
     }
   };
@@ -207,7 +207,27 @@ class List extends Component {
 
 List.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  autoFocus: PropTypes.bool.isRequired,
+  autoFocus: PropTypes.bool,
+  selected: PropTypes.object,
+  properties: PropTypes.array,
+  isInputEmpty: PropTypes.bool,
+  defaultValue: PropTypes.any,
+  dataId: PropTypes.any,
+  rowId: PropTypes.any,
+  tabId: PropTypes.any,
+  windowType: PropTypes.string,
+  filterWidget: PropTypes.any,
+  entity: PropTypes.string,
+  subentity: PropTypes.object,
+  subentityId: PropTypes.string,
+  viewId: PropTypes.any,
+  attribute: PropTypes.any,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  lookupList: PropTypes.bool,
+  setNextProperty: PropTypes.func,
+  mainProperty: PropTypes.any,
+  enableAutofocus: PropTypes.func,
 };
 
 export default connect(false, false, false, { withRef: true })(List);

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -93,7 +93,6 @@ class RawList extends PureComponent {
       loading,
       disableAutofocus,
     } = this.props;
-    const { isFocused, isOpened } = this.state;
 
     if (
       list.length === 0 &&
@@ -103,6 +102,10 @@ class RawList extends PureComponent {
     ) {
       disableAutofocus();
     }
+
+    // if (!this.props.lookupList && this.dropdown.className.indexOf('select-dropdown') > 0) {
+    //   console.log('here1: ', autoFocus, initialFocus, defaultValue)
+    // }
 
     // focus
     if (this.dropdown) {
@@ -148,6 +151,7 @@ class RawList extends PureComponent {
 
     //open
     if (this.dropdown && autoFocus) {
+      // console.log('this.dropdown && autoFocus')
       if (prevState.selected !== this.state.selected) {
         if (!doNotOpenOnFocus && this.state.dropdownList.length > 1) {
           this.openDropdownList();
@@ -180,7 +184,8 @@ class RawList extends PureComponent {
   };
 
   focus = () => {
-    if (this.state.isOpened) {
+    // if (this.state.isOpened) {
+    // console.log('RawList focus')
       if (this.dropdown && this.dropdown.focus) {
         this.dropdown.focus();
       }
@@ -188,7 +193,7 @@ class RawList extends PureComponent {
       this.setState({
         isFocused: true,
       });
-    }
+    // }
   };
 
   blur = () => {
@@ -204,6 +209,7 @@ class RawList extends PureComponent {
   };
 
   openDropdownList = focus => {
+    // console.log('open dropdown')
     this.setState(
       {
         isOpened: true,
@@ -239,8 +245,12 @@ class RawList extends PureComponent {
   handleFocus = () => {
     const { onFocus, doNotOpenOnFocus, autoFocus } = this.props;
 
+    // console.log('RawList handle focus')
+
     if (!doNotOpenOnFocus && !autoFocus) {
       this.openDropdownList(true);
+    } else {
+      this.focus();
     }
 
     onFocus && onFocus();
@@ -260,7 +270,7 @@ class RawList extends PureComponent {
      * on focus.
      */
   handleClick = () => {
-    this.openDropdownList();
+    this.openDropdownList(true);
   };
 
   handleSelect = selected => {
@@ -297,13 +307,26 @@ class RawList extends PureComponent {
       this.navigateToAlphanumeric(e.key);
     } else {
       switch (e.key) {
-        case 'ArrowDown':
-          e.preventDefault();
-          this.navigate(true);
-          break;
         case 'ArrowUp':
           e.preventDefault();
           this.navigate(false);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+
+          if (!isOpened) {
+            this.openDropdownList();
+          } else {
+            this.navigate(true);
+          }
+          break;
+        case 'Space':
+        console.log('space')
+          e.preventDefault();
+
+          if (!isOpened) {
+            this.openDropdownList();
+          }
           break;
         case 'Enter':
           e.preventDefault();
@@ -472,6 +495,10 @@ class RawList extends PureComponent {
           'input-disabled': readonly,
           'input-dropdown-container-static': rowId,
           'input-table': rowId && !isModal,
+          'lookup-dropdown': lookupList,
+          'select-dropdown': !lookupList,
+          focused: isFocused,
+          opened: isOpened,
         })}
         tabIndex={tabIndex ? tabIndex : 0}
         onFocus={readonly ? null : this.handleFocus}
@@ -549,6 +576,14 @@ class RawList extends PureComponent {
 const mapStateToProps = state => ({
   filter: state.windowHandler.filter,
 });
+
+/**
+ * doNotOpenOnFocus - by default we expect user to press space/arrow down when the dropdown field is focused ho
+ *                    show the dropdown with options
+ */
+RawList.defaultProps = {
+  doNotOpenOnFocus: true,
+};
 
 RawList.propTypes = {
   filter: PropTypes.object.isRequired,

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -1,9 +1,9 @@
-import React, { Component, PureComponent } from "react";
-import { connect } from "react-redux";
-import onClickOutside from "react-onclickoutside";
-import ReactCSSTransitionGroup from "react-addons-css-transition-group";
-import TetherComponent from "react-tether";
-import PropTypes from "prop-types";
+import React, { Component, PureComponent } from 'react';
+import { connect } from 'react-redux';
+import onClickOutside from 'react-onclickoutside';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import TetherComponent from 'react-tether';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export class ListDropdown extends Component {
@@ -56,16 +56,16 @@ class RawList extends PureComponent {
       selected: props.selected || 0,
       dropdownList: props.list || [],
       isOpen: false,
-      isFocused: props.autoFocus
+      isFocused: props.autoFocus,
     };
   }
 
   componentWillMount() {
-    window.addEventListener("keydown", this.handleTab);
+    window.addEventListener('keydown', this.handleTab);
   }
 
   componentWillUnmount() {
-    window.removeEventListener("keydown", this.handleTab);
+    window.removeEventListener('keydown', this.handleTab);
   }
 
   componentDidMount() {
@@ -92,7 +92,7 @@ class RawList extends PureComponent {
       doNotOpenOnFocus,
       lastProperty,
       loading,
-      disableAutofocus
+      disableAutofocus,
     } = this.props;
 
     if (
@@ -151,14 +151,14 @@ class RawList extends PureComponent {
         this.setState({
           ...openDropdownState,
           dropdownList: dropdownList,
-          selected: defaultValue ? defaultValue : list[0]
+          selected: defaultValue ? defaultValue : list[0],
         });
       }
     }
 
     if (prevProps.selected !== selected) {
       this.setState({
-        selected: selected
+        selected: selected,
       });
     }
 
@@ -191,7 +191,7 @@ class RawList extends PureComponent {
       }
 
       this.setState({
-        isFocused: true
+        isFocused: true,
       });
     }
   };
@@ -203,7 +203,7 @@ class RawList extends PureComponent {
       }
 
       this.setState({
-        isFocused: false
+        isFocused: false,
       });
     }
   };
@@ -211,7 +211,7 @@ class RawList extends PureComponent {
   openDropdownList = focus => {
     this.setState(
       {
-        isOpen: true
+        isOpen: true,
       },
       () => {
         focus && this.focus();
@@ -225,7 +225,7 @@ class RawList extends PureComponent {
     if (isOpen) {
       this.setState(
         {
-          isOpen: false
+          isOpen: false,
         },
         this.blur
       );
@@ -279,7 +279,7 @@ class RawList extends PureComponent {
 
     this.setState(
       {
-        selected: option || 0
+        selected: option || 0,
       },
       () => {
         this.handleBlur();
@@ -290,7 +290,7 @@ class RawList extends PureComponent {
 
   handleSwitch = option => {
     this.setState({
-      selected: option || 0
+      selected: option || 0,
     });
   };
 
@@ -302,16 +302,15 @@ class RawList extends PureComponent {
       this.navigateToAlphanumeric(e.key);
     } else {
       switch (e.key) {
-        case "ArrowDown":
+        case 'ArrowDown':
           e.preventDefault();
           this.navigate(true);
           break;
-
-        case "ArrowUp":
+        case 'ArrowUp':
           e.preventDefault();
           this.navigate(false);
           break;
-        case "Enter":
+        case 'Enter':
           e.preventDefault();
 
           if (isOpen) {
@@ -325,14 +324,12 @@ class RawList extends PureComponent {
           }
 
           break;
-
-        case "Escape":
+        case 'Escape':
           e.preventDefault();
           this.handleBlur();
           this.closeDropdownList();
           break;
-
-        case "Tab":
+        case 'Tab':
           list.length === 0 && !readonly && onSelect(null);
           break;
       }
@@ -342,7 +339,7 @@ class RawList extends PureComponent {
   handleTab = ({ key }) => {
     const { isOpen } = this.state;
 
-    if (key === "Tab" && isOpen) {
+    if (key === 'Tab' && isOpen) {
       this.closeDropdownList();
     }
   };
@@ -387,7 +384,7 @@ class RawList extends PureComponent {
     }
 
     this.setState({
-      selected: item
+      selected: item,
     });
   };
 
@@ -412,31 +409,29 @@ class RawList extends PureComponent {
       selected:
         next >= 0 && next <= dropdownList.length - 1
           ? dropdownList[next]
-          : selected
+          : selected,
     });
   };
 
   getRow = (option, index) => {
     const { defaultValue } = this.props;
     const { selected } = this.state;
-
     const value = defaultValue ? defaultValue.caption : null;
-
-    const classes = ["input-dropdown-list-option ignore-react-onclickoutside"];
+    const classes = ['input-dropdown-list-option ignore-react-onclickoutside'];
 
     if (selected != null && selected !== 0) {
       if (
         selected.key === option.key ||
         (!selected && (value === option.caption || (!value && index === 0)))
       ) {
-        classes.push("input-dropdown-list-option-key-on");
+        classes.push('input-dropdown-list-option-key-on');
       }
     }
 
     return (
       <div
         key={option.key}
-        className={classes.join(" ")}
+        className={classes.join(' ')}
         onMouseEnter={() => this.handleSwitch(option)}
         onClick={() => this.handleSelect(option)}
       >
@@ -482,11 +477,11 @@ class RawList extends PureComponent {
       lookupList
     } = this.props;
 
-    let placeholder = "";
+    let placeholder = '';
     const isListEmpty = list.length === 0;
     const { isOpen, isFocused } = this.state;
 
-    if (typeof defaultValue === "string") {
+    if (typeof defaultValue === 'string') {
       placeholder = defaultValue;
     } else {
       placeholder = defaultValue && defaultValue.caption;
@@ -501,7 +496,7 @@ class RawList extends PureComponent {
     }
 
     if (!value) {
-      value = "";
+      value = '';
     }
 
     return (
@@ -510,7 +505,7 @@ class RawList extends PureComponent {
         className={classnames('input-dropdown-container', {
           'input-disabled': readonly,
           'input-dropdown-container-static': rowId,
-          'input-table': (rowId && !isModal)
+          'input-table': rowId && !isModal,
         })}
         tabIndex={tabIndex ? tabIndex : 0}
         onFocus={readonly ? null : this.handleFocus}
@@ -522,38 +517,37 @@ class RawList extends PureComponent {
           targetAttachment="bottom left"
           constraints={[
             {
-              to: "scrollParent"
+              to: 'scrollParent',
             },
             {
-              to: "window",
-              pin: ["bottom"]
-            }
+              to: 'window',
+              pin: ['bottom'],
+            },
           ]}
         >
           <div
-            className={classnames('input-dropdown input-block input-readonly',{
+            className={classnames('input-dropdown input-block input-readonly', {
               'input-secondary': rank,
-              'pulse': updated,
-              'input-mandatory': (mandatory && !selected),
-              'input-error': (validStatus
-                && (!validStatus.valid && !validStatus.initialValue) &&
-              !isOpen)
-              })
-            }
+              pulse: updated,
+              'input-mandatory': mandatory && !selected,
+              'input-error':
+                validStatus &&
+                (!validStatus.valid && !validStatus.initialValue) &&
+                !isOpen,
+            })}
             ref={c => (this.inputContainer = c)}
           >
             <div
-              className={
-                "input-editable input-dropdown-focused " +
-                (align ? "text-xs-" + align + " " : "")
-              }
+              className={classnames('input-editable input-dropdown-focused', {
+                [`text-xs-${align}`]: align,
+              })}
             >
               <input
                 type="text"
                 className={
-                  "input-field js-input-field " +
-                  "font-weight-semibold " +
-                  (disabled ? "input-disabled " : "")
+                  'input-field js-input-field ' +
+                  'font-weight-semibold ' +
+                  (disabled ? 'input-disabled ' : '')
                 }
                 readOnly
                 tabIndex={-1}

--- a/src/components/widget/List/RawListDropdown.js
+++ b/src/components/widget/List/RawListDropdown.js
@@ -1,0 +1,45 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+
+export default class RawListDropdown extends PureComponent {
+  static propTypes = {
+    isListEmpty: PropTypes.bool,
+    offsetWidth: PropTypes.number,
+    loading: PropTypes.bool,
+    children: PropTypes.any,
+  };
+
+  render() {
+    const { isListEmpty, offsetWidth, loading, children } = this.props;
+
+    return (
+      <div
+        className="input-dropdown-list"
+        style={{ width: `${offsetWidth}px` }}
+      >
+        {isListEmpty &&
+          loading === false && (
+            <div className="input-dropdown-list-header">
+              There is no choice available
+            </div>
+          )}
+        {loading &&
+          isListEmpty && (
+            <div className="input-dropdown-list-header">
+              <ReactCSSTransitionGroup
+                transitionName="rotate"
+                transitionEnterTimeout={1000}
+                transitionLeaveTimeout={1000}
+              >
+                <div className="rotate icon-rotate">
+                  <i className="meta-icon-settings" />
+                </div>
+              </ReactCSSTransitionGroup>
+            </div>
+          )}
+        {children}
+      </div>
+    );
+  }
+}

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -333,7 +333,7 @@ class Lookup extends Component {
                     }}
                     readonly={disabled || readonly}
                     lookupList={true}
-                    autofocus={isCurrentProperty}
+                    autoFocus={isCurrentProperty}
                     properties={[item]}
                     mainProperty={[item]}
                     defaultValue={

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -1,10 +1,11 @@
-import React, { Component } from "react";
-import onClickOutside from "react-onclickoutside";
-import { connect } from "react-redux";
+import React, { Component } from 'react';
+import onClickOutside from 'react-onclickoutside';
+import { connect } from 'react-redux';
+import classnames from 'classnames';
 
-import { getItemsByProperty } from "../../../actions/WindowActions";
-import List from "../List/List";
-import RawLookup from "./RawLookup";
+import { getItemsByProperty } from '../../../actions/WindowActions';
+import List from '../List/List';
+import RawLookup from './RawLookup';
 
 class Lookup extends Component {
   constructor(props) {
@@ -12,18 +13,14 @@ class Lookup extends Component {
 
     this.state = {
       isInputEmpty: true,
-      propertiesCopy: getItemsByProperty(
-        this.props.properties,
-        "source",
-        "list"
-      ),
-      property: "",
+      propertiesCopy: getItemsByProperty(props.properties, 'source', 'list'),
+      property: '',
       fireClickOutside: false,
       initialFocus: false,
       localClearing: false,
       fireDropdownList: false,
       autofocusDisabled: false,
-      isDropdownListOpen: false
+      isDropdownListOpen: false,
     };
   }
 
@@ -38,7 +35,7 @@ class Lookup extends Component {
       defaultValue.map(item => {
         if (item.value) {
           this.setState({
-            isInputEmpty: false
+            isInputEmpty: false,
           });
         }
       });
@@ -59,7 +56,7 @@ class Lookup extends Component {
           let nextProp = properties[nextIndex];
 
           // TODO: Looks like this code was never used
-          if (nextProp.source === "list") {
+          if (nextProp.source === 'list') {
             this.linkedList.map(listComponent => {
               if (listComponent && listComponent.props) {
                 let listProp = listComponent.props.mainProperty;
@@ -83,17 +80,17 @@ class Lookup extends Component {
             });
 
             this.setState({
-              property: nextProp.field
+              property: nextProp.field,
             });
           } else {
             this.setState({
-              property: nextProp.field
+              property: nextProp.field,
             });
           }
         } else if (defaultValue[defaultValue.length - 1].field === prop) {
           this.setState(
             {
-              property: ""
+              property: '',
             },
             () => {
               onBlurWidget && onBlurWidget();
@@ -107,11 +104,11 @@ class Lookup extends Component {
   openDropdownList = () => {
     this.setState(
       {
-        fireDropdownList: true
+        fireDropdownList: true,
       },
       () => {
         this.setState({
-          fireDropdownList: false
+          fireDropdownList: false,
         });
       }
     );
@@ -121,7 +118,7 @@ class Lookup extends Component {
     const { onFocus, onHandleBlur } = this.props;
 
     this.setState({
-      isDropdownListOpen: value
+      isDropdownListOpen: value,
     });
 
     if (value && onFocus) {
@@ -133,7 +130,7 @@ class Lookup extends Component {
 
   resetLocalClearing = () => {
     this.setState({
-      localClearing: false
+      localClearing: false,
     });
   };
 
@@ -142,11 +139,11 @@ class Lookup extends Component {
       this.setState(
         {
           fireClickOutside: true,
-          property: ""
+          property: '',
         },
         () => {
           this.setState({
-            fireClickOutside: false
+            fireClickOutside: false,
           });
         }
       );
@@ -155,7 +152,7 @@ class Lookup extends Component {
 
   handleInputEmptyStatus = isEmpty => {
     this.setState({
-      isInputEmpty: isEmpty
+      isInputEmpty: isEmpty,
     });
   };
 
@@ -168,22 +165,22 @@ class Lookup extends Component {
 
     this.setState({
       isInputEmpty: true,
-      property: "",
+      property: '',
       initialFocus: true,
       localClearing: true,
-      autofocusDisabled: false
+      autofocusDisabled: false,
     });
   };
 
   disableAutofocus = () => {
     this.setState({
-      autofocusDisabled: true
+      autofocusDisabled: true,
     });
   };
 
   enableAutofocus = () => {
     this.setState({
-      autofocusDisabled: false
+      autofocusDisabled: false,
     });
   };
 
@@ -214,7 +211,7 @@ class Lookup extends Component {
       subentityId,
       viewId,
       autoFocus,
-      newRecordWindowId
+      newRecordWindowId,
     } = this.props;
 
     const {
@@ -224,42 +221,44 @@ class Lookup extends Component {
       initialFocus,
       localClearing,
       fireDropdownList,
-      autofocusDisabled
+      autofocusDisabled,
     } = this.state;
 
     this.linkedList = [];
 
+    const mandatoryInputCondition =
+      mandatory &&
+      (isInputEmpty ||
+        (validStatus && validStatus.initialValue && !validStatus.valid));
+    const errorInputCondition =
+      validStatus && (!validStatus.valid && !validStatus.initialValue);
+
     return (
       <div
         ref={c => (this.dropdown = c)}
-        className={
-          "input-dropdown-container lookup-wrapper input-" +
-          (rank ? rank : "primary") +
-          (updated ? " pulse-on" : " pulse-off") +
-          (filterWidget ? " input-full" : "") +
-          (mandatory &&
-          (isInputEmpty ||
-            (validStatus && validStatus.initialValue && !validStatus.valid))
-            ? " input-mandatory"
-            : "") +
-          (validStatus && (!validStatus.valid && !validStatus.initialValue)
-            ? " input-error"
-            : "") +
-          (readonly ? " lookup-wrapper-disabled" : "")
-        }
+        className={classnames('input-dropdown-container lookup-wrapper', {
+          [`input-${rank}`]: rank,
+          'input-primary': !rank,
+          'pulse-on': updated,
+          'pulse-off': !updated,
+          'input-full': filterWidget,
+          'input-mandatory': mandatoryInputCondition,
+          'input-error': errorInputCondition,
+          'lookup-wrapper-disabled': readonly,
+        })}
       >
         {properties &&
           properties.map((item, index) => {
             const disabled = isInputEmpty && index !== 0;
             const itemByProperty = getItemsByProperty(
               defaultValue,
-              "field",
+              'field',
               item.field
             )[0];
             if (
-              item.source === "lookup" ||
-              item.widgetType === "Lookup" ||
-              (itemByProperty && itemByProperty.widgetType === "Lookup")
+              item.source === 'lookup' ||
+              item.widgetType === 'Lookup' ||
+              (itemByProperty && itemByProperty.widgetType === 'Lookup')
             ) {
               return (
                 <RawLookup
@@ -304,14 +303,14 @@ class Lookup extends Component {
                     rowId,
                     newRecordCaption,
                     newRecordWindowId,
-                    localClearing
+                    localClearing,
                   }}
                 />
               );
             } else if (
-              item.source === "list" ||
-              item.widgetType === "List" ||
-              (itemByProperty && itemByProperty.source === "List")
+              item.source === 'list' ||
+              item.widgetType === 'List' ||
+              (itemByProperty && itemByProperty.source === 'List')
             ) {
               const isFirstProperty = index === 0;
               const isCurrentProperty =
@@ -320,10 +319,12 @@ class Lookup extends Component {
               return (
                 <div
                   key={index}
-                  className={
-                    "raw-lookup-wrapper raw-lookup-wrapper-bcg " +
-                    (disabled || readonly ? "raw-lookup-disabled" : "")
-                  }
+                  className={classnames(
+                    'raw-lookup-wrapper raw-lookup-wrapper-bcg ',
+                    {
+                      'raw-lookup-disabled': disabled || readonly,
+                    }
+                  )}
                 >
                   <List
                     ref={c => {
@@ -334,10 +335,11 @@ class Lookup extends Component {
                     readonly={disabled || readonly}
                     lookupList={true}
                     autoFocus={isCurrentProperty}
+                    doNotOpenOnFocus={false}
                     properties={[item]}
                     mainProperty={[item]}
                     defaultValue={
-                      itemByProperty.value ? itemByProperty.value : ""
+                      itemByProperty.value ? itemByProperty.value : ''
                     }
                     initialFocus={isFirstProperty ? initialFocus : false}
                     blur={!property ? true : false}
@@ -358,7 +360,7 @@ class Lookup extends Component {
                       viewId,
                       onChange,
                       isInputEmpty,
-                      property
+                      property,
                     }}
                   />
                 </div>

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -232,20 +232,23 @@ class Lookup extends Component {
         (validStatus && validStatus.initialValue && !validStatus.valid));
     const errorInputCondition =
       validStatus && (!validStatus.valid && !validStatus.initialValue);
+    const classRank = rank || 'primary';
 
     return (
       <div
         ref={c => (this.dropdown = c)}
-        className={classnames('input-dropdown-container lookup-wrapper', {
-          [`input-${rank}`]: rank,
-          'input-primary': !rank,
-          'pulse-on': updated,
-          'pulse-off': !updated,
-          'input-full': filterWidget,
-          'input-mandatory': mandatoryInputCondition,
-          'input-error': errorInputCondition,
-          'lookup-wrapper-disabled': readonly,
-        })}
+        className={classnames(
+          'input-dropdown-container lookup-wrapper',
+          `input-${classRank}`,
+          {
+            'pulse-on': updated,
+            'pulse-off': !updated,
+            'input-full': filterWidget,
+            'input-mandatory': mandatoryInputCondition,
+            'input-error': errorInputCondition,
+            'lookup-wrapper-disabled': readonly,
+          }
+        )}
       >
         {properties &&
           properties.map((item, index) => {

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -486,7 +486,7 @@ class RawWidget extends Component {
             subentity={subentity}
             subentityId={subentityId}
             defaultValue={fields[0].emptyText}
-            selected={widgetData[0].value}
+            selected={widgetData[0].value || null}
             properties={fields}
             readonly={widgetData[0].readonly || disabled}
             mandatory={widgetData[0].mandatory}


### PR DESCRIPTION
Param name was wrong. I'm not sure how this was working before but this solves #1554 . Also refactored List and RawList components, decoupling them, extracting some code to a separate function (which will make this easier to test) and moving focus/toggle control to parent component. Now it should be easier to debug and understand what's going on when events are not flying around like crazy.
This also changes how select fields behave when selected with keyboard. No by default they are focused (which a visual indication) first and require user to click arrow down to show the list. Lookup fields work as before.