### PR TITLE
No initial date in DateRange input

### DIFF
--- a/src/components/widget/DatetimeRange.js
+++ b/src/components/widget/DatetimeRange.js
@@ -1,48 +1,35 @@
-import Moment from "moment";
-import React, { Component } from "react";
-import DateRangePicker from "react-bootstrap-daterangepicker";
-import counterpart from "counterpart";
+import Moment from 'moment';
+import React, { Component } from 'react';
+import DateRangePicker from 'react-bootstrap-daterangepicker';
+import counterpart from 'counterpart';
+import classnames from 'classnames';
 
 class DatetimeRange extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      startDate: null,
-      endDate: null
+      startDate: undefined,
+      endDate: undefined,
     };
   }
 
   componentDidMount() {
-    const { value, valueTo, onChange } = this.props;
+    const { value, valueTo } = this.props;
     if (value && valueTo) {
       this.setState({
         startDate: Moment(value),
-        endDate: Moment(valueTo)
+        endDate: Moment(valueTo),
       });
-    } else {
-      let initStartDate = new Date();
-      let initEndDate = new Date();
-      initStartDate.setHours(0, 0, 0, 0);
-      initEndDate.setHours(23, 59, 0, 0);
-      this.setState(
-        {
-          startDate: initStartDate,
-          endDate: initEndDate
-        },
-        () => {
-          onChange(initStartDate, initEndDate);
-        }
-      );
     }
   }
 
-  handleEvent = (event, picker) => {
+  handleApply = (event, picker) => {
     const { onChange } = this.props;
 
     this.setState(
       {
         startDate: picker.startDate,
-        endDate: picker.endDate
+        endDate: picker.endDate,
       },
       () => {
         onChange(picker.startDate, picker.endDate);
@@ -51,31 +38,35 @@ class DatetimeRange extends Component {
   };
 
   render() {
-    const today = counterpart.translate("window.daterange.today");
-    const yesterday = counterpart.translate("window.daterange.yesterday");
-    const last7days = counterpart.translate("window.daterange.last7days");
-    const last30days = counterpart.translate("window.daterange.last30days");
-    const thisMonth = counterpart.translate("window.daterange.thismonth");
-    const lastMonth = counterpart.translate("window.daterange.lastmonth");
+    const today = counterpart.translate('window.daterange.today');
+    const yesterday = counterpart.translate('window.daterange.yesterday');
+    const last7days = counterpart.translate('window.daterange.last7days');
+    const last30days = counterpart.translate('window.daterange.last30days');
+    const thisMonth = counterpart.translate('window.daterange.thismonth');
+    const lastMonth = counterpart.translate('window.daterange.lastmonth');
     const ranges = {
       [today]: [Moment(), Moment()],
-      [yesterday]: [Moment().subtract(1, "days"), Moment().subtract(1, "days")],
-      [last7days]: [Moment().subtract(6, "days"), Moment()],
-      [last30days]: [Moment().subtract(29, "days"), Moment()],
-      [thisMonth]: [Moment().startOf("month"), Moment().endOf("month")],
+      [yesterday]: [Moment().subtract(1, 'days'), Moment().subtract(1, 'days')],
+      [last7days]: [Moment().subtract(6, 'days'), Moment()],
+      [last30days]: [Moment().subtract(29, 'days'), Moment()],
+      [thisMonth]: [Moment().startOf('month'), Moment().endOf('month')],
       [lastMonth]: [
         Moment()
-          .subtract(1, "month")
-          .startOf("month"),
+          .subtract(1, 'month')
+          .startOf('month'),
         Moment()
-          .subtract(1, "month")
-          .endOf("month")
-      ]
+          .subtract(1, 'month')
+          .endOf('month'),
+      ],
     };
     const { startDate, endDate } = this.state;
     const { onShow, onHide, mandatory, validStatus, timePicker } = this.props;
+    const fmt = timePicker ? 'L LT' : 'L';
 
-    const format = timePicker ? "L LT" : "L";
+    const availableDates =
+      !!startDate && !!endDate
+        ? ` ${Moment(startDate).format(fmt)} - ${Moment(endDate).format(fmt)}`
+        : ' All dates available';
 
     return (
       <DateRangePicker
@@ -83,35 +74,30 @@ class DatetimeRange extends Component {
         endDate={endDate}
         ranges={ranges}
         alwaysShowCalendars={true}
-        onApply={this.handleEvent}
+        onApply={this.handleApply}
         onShow={onShow}
         onHide={onHide}
         locale={{
           firstDay: 1,
           monthNames: Moment.months(),
           daysOfWeek: Moment.weekdaysMin(),
-          applyLabel: counterpart.translate("window.daterange.apply"),
-          cancelLabel: counterpart.translate("window.daterange.cancel"),
-          customRangeLabel: counterpart.translate("window.daterange.custom")
+          applyLabel: counterpart.translate('window.daterange.apply'),
+          cancelLabel: counterpart.translate('window.daterange.cancel'),
+          customRangeLabel: counterpart.translate('window.daterange.custom'),
         }}
         autoApply={false}
         timePicker={timePicker}
-        timePicker24Hour={true}
-      >
+        timePicker24Hour={true}>
         <button
-          className={
-            "btn btn-block text-xs-left btn-meta-outline-secondary " +
-            "btn-distance btn-sm input-icon-container input-primary " +
-            (mandatory && !startDate && !endDate ? "input-mandatory " : "") +
-            (validStatus && !validStatus.valid ? "input-error " : "")
-          }
-        >
-          {!!startDate && !!endDate
-            ? " " +
-              Moment(startDate).format(format) +
-              " - " +
-              Moment(endDate).format(format)
-            : " All dates available"}
+          className={classnames(
+            'btn', 'btn-block', 'text-xs-left', 'btn-meta-outline-secondary',
+            'btn-distance', 'btn-sm input-icon-container', 'input-primary',
+            {
+              'input-mandatory': mandatory && !startDate && !endDate,
+              'input-error': validStatus && !validStatus.valid,
+            }
+          )}>
+          {availableDates}
           <i className="meta-icon-calendar input-icon-right" />
         </button>
       </DateRangePicker>

--- a/src/components/widget/DatetimeRange.js
+++ b/src/components/widget/DatetimeRange.js
@@ -66,7 +66,7 @@ class DatetimeRange extends Component {
     const availableDates =
       !!startDate && !!endDate
         ? ` ${Moment(startDate).format(fmt)} - ${Moment(endDate).format(fmt)}`
-        : ' All dates available';
+        : counterpart.translate('window.daterange.filter.hint');
 
     return (
       <DateRangePicker


### PR DESCRIPTION
Input for selecting DateRange now won't have initial date (when start/end date not provided).
Plus refactoring.

Relates to #1546 .