### PR TITLE
Fix copying edited table cells

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -753,8 +753,9 @@ class Table extends Component {
     e.preventDefault();
 
     const cell = e.target;
+    const textValue = cell.value || cell.textContent;
 
-    e.clipboardData.setData("text/plain", cell.textContent);
+    e.clipboardData.setData("text/plain", textValue);
   };
 
   handleZoomInto = fieldName => {
@@ -1014,6 +1015,7 @@ class Table extends Component {
               )
             }
             onItemChange={this.handleItemChange}
+            onCopy={this.handleCopy}
           />
         </tbody>
       ));


### PR DESCRIPTION
The previous fix didn't handle the case when cell is edited. I'm not sure if it ever worked, but now seems to be returning the correct data. Depending on the field type we either take `textContent` or input's `value`.

Improvement for #1593 