### PR TITLE
Don't call Moment functions on strings

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -312,10 +312,13 @@ class RawWidget extends Component {
                 inputProps={{
                   placeholder: fields[0].emptyText,
                   disabled: widgetData[0].readonly || disabled,
-                  tabIndex: fullScreen ? -1 : tabIndex
+                  tabIndex: fullScreen ? -1 : tabIndex,
                 }}
                 value={widgetValue || widgetData[0].value}
-                onChange={date => handleChange(widgetField, date.utc(true))}
+                onChange={date => {
+                  const finalDate = date.utc ? date.utc(true) : date;
+                  return handleChange(widgetField, finalDate);
+                }}
                 patch={date =>
                   this.handlePatch(
                     widgetField,


### PR DESCRIPTION
Simple fix. We can only call the `utc(true)` function which resets timezones on Moment objects.

Relates to #1585 