### PR TITLE
Fix days shown in the DateRange calendar

### DIFF
--- a/src/components/widget/DatetimeRange.js
+++ b/src/components/widget/DatetimeRange.js
@@ -80,7 +80,6 @@ class DatetimeRange extends Component {
         locale={{
           firstDay: 1,
           monthNames: Moment.months(),
-          daysOfWeek: Moment.weekdaysMin(),
           applyLabel: counterpart.translate('window.daterange.apply'),
           cancelLabel: counterpart.translate('window.daterange.cancel'),
           customRangeLabel: counterpart.translate('window.daterange.custom'),


### PR DESCRIPTION
We were using days of the weeks starting from Sunday on a calendar starting from Monday.

This will make #1604 go away.