### PR TITLE
Show date using the same formatting in TableCells

### DIFF
--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -176,6 +176,9 @@ class TableCell extends Component {
         )
       : null;
     const isOpenDatePicker = isEdited && item.widgetType === 'Date';
+    const isDateField = TableCell.DATE_FIELD_FORMATS[item.widgetType]
+      ? TableCell.getDateFormat(item.widgetType)
+      : false;
 
     return (
       <td
@@ -201,6 +204,7 @@ class TableCell extends Component {
           <MasterWidget
             {...item}
             entity={mainTable ? 'window' : entity}
+            dateFormat={isDateField}
             dataId={mainTable ? null : docId}
             widgetData={widgetData}
             windowType={type}

--- a/src/components/widget/DatePicker.js
+++ b/src/components/widget/DatePicker.js
@@ -1,12 +1,12 @@
-import PropTypes from "prop-types";
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import TetheredDateTime from "./TetheredDateTime";
-import { addNotification } from "../../actions/AppActions";
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import TetheredDateTime from './TetheredDateTime';
+import { addNotification } from '../../actions/AppActions';
 import {
   allowOutsideClick,
-  disableOutsideClick
-} from "../../actions/WindowActions";
+  disableOutsideClick,
+} from '../../actions/WindowActions';
 
 const propTypes = {
   dispatch: PropTypes.func.isRequired,
@@ -14,7 +14,7 @@ const propTypes = {
   patch: PropTypes.func,
   field: PropTypes.string,
   value: PropTypes.any,
-  isOpenDatePicker: PropTypes.bool
+  isOpenDatePicker: PropTypes.bool,
 };
 
 class DatePicker extends Component {
@@ -22,7 +22,7 @@ class DatePicker extends Component {
     super(props);
     this.state = {
       open: false,
-      cache: null
+      cache: null,
     };
   }
 
@@ -43,13 +43,13 @@ class DatePicker extends Component {
     try {
       if (
         JSON.stringify(cache) !==
-        (date !== "" ? JSON.stringify(date && date.toDate()) : "")
+        (date !== '' ? JSON.stringify(date && date.toDate()) : '')
       ) {
         patch(date);
       }
     } catch (error) {
       dispatch(
-        addNotification(field, `${field} has an invalid date.`, 5000, "error")
+        addNotification(field, `${field} has an invalid date.`, 5000, 'error')
       );
     }
 
@@ -62,7 +62,7 @@ class DatePicker extends Component {
     const { value, dispatch } = this.props;
     this.setState({
       cache: value,
-      open: true
+      open: true,
     });
     dispatch(disableOutsideClick());
   };
@@ -70,7 +70,7 @@ class DatePicker extends Component {
   handleClose = () => {
     const { dispatch } = this.props;
     this.setState({
-      open: false
+      open: false,
     });
     dispatch(allowOutsideClick());
   };

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -250,7 +250,8 @@ class RawWidget extends Component {
       allowShowPassword,
       onBlurWidget,
       defaultValue,
-      isOpenDatePicker
+      isOpenDatePicker,
+      dateFormat
     } = this.props;
     const widgetValue = data || widgetData[0].value;
     const { isEdited } = this.state;
@@ -307,7 +308,7 @@ class RawWidget extends Component {
                 key={1}
                 field={fields[0].field}
                 timeFormat={false}
-                dateFormat={true}
+                dateFormat={dateFormat || true}
                 isOpenDatePicker={isOpenDatePicker}
                 inputProps={{
                   placeholder: fields[0].emptyText,
@@ -365,8 +366,8 @@ class RawWidget extends Component {
             <div className={this.getClassNames({ icon: true })}>
               <DatePicker
                 field={fields[0].field}
-                timeFormat={true}
-                dateFormat={true}
+                timeFormat={dateFormat ? false : true}
+                dateFormat={dateFormat || true}
                 inputProps={{
                   placeholder: fields[0].emptyText,
                   disabled: widgetData[0].readonly || disabled,
@@ -414,7 +415,7 @@ class RawWidget extends Component {
             <DatePicker
               field={fields[0].field}
               timeFormat={true}
-              dateFormat={false}
+              dateFormat={dateFormat || true}
               inputProps={{
                 placeholder: fields[0].emptyText,
                 disabled: widgetData[0].readonly || disabled,


### PR DESCRIPTION
Right now we were showing different datetime formats in table depending on the field editable state. readonly cell was using our predefined format, so I changed the picker field to use the same.

Relates to #1567