### PR TITLE
Fix loading attributes editor

### DIFF
--- a/src/components/DataLayoutWrapper.js
+++ b/src/components/DataLayoutWrapper.js
@@ -1,8 +1,8 @@
-import React, { cloneElement, Component } from "react";
-import { connect } from "react-redux";
+import React, { cloneElement, Component } from 'react';
+import { connect } from 'react-redux';
 
-import { patchViewAttributes } from "../actions/ViewAttributesActions";
-import { parseToDisplay } from "../actions/WindowActions";
+import { patchViewAttributes } from '../actions/ViewAttributesActions';
+import { parseToDisplay } from '../actions/WindowActions';
 
 class DataLayoutWrapper extends Component {
   constructor(props) {
@@ -11,7 +11,7 @@ class DataLayoutWrapper extends Component {
     this.state = {
       layout: [],
       data: [],
-      dataId: null
+      dataId: null,
     };
   }
 
@@ -29,9 +29,9 @@ class DataLayoutWrapper extends Component {
         ...this.state.data,
         [field]: {
           ...this.state.data[field],
-          value
-        }
-      }
+          value,
+        },
+      },
     });
   };
 
@@ -51,7 +51,7 @@ class DataLayoutWrapper extends Component {
                 ...this.state.data,
                 [key]: {
                   ...this.state.data[key],
-                  ...preparedData[key]
+                  ...preparedData[key],
                 }
               }
             });
@@ -70,7 +70,7 @@ class DataLayoutWrapper extends Component {
       this.setState(
         {
           data: preparedData,
-          dataId: dataId
+          dataId: dataId,
         },
         () => {
           cb && cb();
@@ -82,7 +82,7 @@ class DataLayoutWrapper extends Component {
     this.mounted &&
       this.setState(
         {
-          layout: layout
+          layout: layout,
         },
         () => {
           cb && cb();
@@ -95,7 +95,7 @@ class DataLayoutWrapper extends Component {
     const { children, className } = this.props;
 
     // sometimes it's a number, and React complaints about wrong type
-    const dataId = this.state.dataId + "";
+    const dataId = this.state.dataId + '';
 
     return (
       <div className={className}>
@@ -110,7 +110,7 @@ class DataLayoutWrapper extends Component {
           DLWrapperSetData: this.setData,
           DLWrapperSetLayout: this.setLayout,
           DLWrapperHandleChange: this.handleChange,
-          DLWrapperHandlePatch: this.handlePatch
+          DLWrapperHandlePatch: this.handlePatch,
         })}
       </div>
     );

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -33,7 +33,7 @@ import {
   selectTableItems,
   removeSelectedTableItems,
 } from '../../actions/WindowActions';
-import { getSelectionDirect } from '../../reducers/windowHandler';
+import { getSelection, getSelectionDirect } from '../../reducers/windowHandler';
 import BlankPage from '../BlankPage';
 import DataLayoutWrapper from '../DataLayoutWrapper';
 import Filters from '../filters/Filters';
@@ -56,6 +56,9 @@ class DocumentList extends Component {
     // from @connect
     dispatch: PropTypes.func.isRequired,
     selections: PropTypes.object.isRequired,
+    childSelected: PropTypes.array.isRequired,
+    parentSelected: PropTypes.array.isRequired,
+    selected: PropTypes.array.isRequired,
   };
 
   static contextTypes = {
@@ -195,6 +198,15 @@ class DocumentList extends Component {
     return !!nextState.layout && !!nextState.data;
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { setModalDescription } = this.props;
+    const { data } = this.state;
+
+    if (prevState.data !== data && setModalDescription) {
+      setModalDescription(data.description);
+    }
+  }
+
   connectWebSocket = viewId => {
     const { windowType } = this.props;
     connectWS.call(this, `/view/${viewId}`, msg => {
@@ -239,15 +251,6 @@ class DocumentList extends Component {
     });
   };
 
-  componentDidUpdate(prevProps, prevState) {
-    const { setModalDescription } = this.props;
-    const { data } = this.state;
-
-    if (prevState.data !== data && setModalDescription) {
-      setModalDescription(data.description);
-    }
-  }
-
   updateQuickActions = childSelection => {
     if (this.quickActionsComponent) {
       this.quickActionsComponent.updateActions(childSelection);
@@ -257,18 +260,25 @@ class DocumentList extends Component {
   /**
    * load supportAttribute of the selected row from the table
    */
-  loadSupportAttributeFlag = () => {
-    const { selected } = this.getSelected();
+  loadSupportAttributeFlag = ({ selected }) => {
     const { data } = this.state;
     if (!data) {
       return;
     }
     const rows = getRowsData(data.result);
+
     if (selected.length === 1) {
       const selectedRow = rows.find(row => row.id === selected[0]);
+
       this.supportAttribute = selectedRow && selectedRow.supportAttributes;
+      this.setState({
+        supportAttribute: selectedRow && selectedRow.supportAttributes,
+      });
     } else {
       this.supportAttribute = false;
+      this.setState({
+        supportAttribute: false,
+      });
     }
   };
 
@@ -673,6 +683,7 @@ class DocumentList extends Component {
       isShowIncluded,
       hasShowIncluded,
       refreshSelection,
+      supportAttribute,
     } = this.state;
 
     const { selected, childSelected, parentSelected } = this.getSelected();
@@ -708,7 +719,8 @@ class DocumentList extends Component {
           className={classnames('document-list-wrapper', {
             'document-list-included': isShowIncluded || isIncluded,
             'document-list-has-included': hasShowIncluded || hasIncluded,
-          })}>
+          })}
+        >
           {!readonly && (
             <div className="panel panel-primary panel-spaced panel-inline document-list-header">
               <div className={hasIncluded ? 'disabled' : ''}>
@@ -827,16 +839,18 @@ class DocumentList extends Component {
                 hasIncluded,
                 viewId,
                 windowType,
-              }}>
+              }}
+            >
               {layout.supportAttributes &&
                 !isIncluded &&
                 !hasIncluded && (
                   <DataLayoutWrapper
                     className="table-flex-wrapper attributes-selector js-not-unselect"
                     entity="documentView"
-                    {...{ windowType, viewId }}>
+                    {...{ windowType, viewId }}
+                  >
                     <SelectionAttributes
-                      supportAttribute={this.supportAttribute}
+                      supportAttribute={supportAttribute}
                       setClickOutsideLock={this.setClickOutsideLock}
                       selected={selectionValid ? selected : undefined}
                       shouldNotUpdate={inBackground}
@@ -853,8 +867,28 @@ class DocumentList extends Component {
   }
 }
 
-const mapStateToProps = ({ windowHandler }) => ({
-  selections: windowHandler.selections,
+const mapStateToProps = (state, props) => ({
+  selections: state.windowHandler.selections,
+  selected: getSelection({
+    state,
+    windowType: props.windowType,
+    viewId: props.defaultViewId,
+  }),
+  childSelected:
+    props.includedView && props.includedView.windowType
+      ? getSelection({
+          state,
+          windowType: props.includedView.windowType,
+          viewId: props.includedView.viewId,
+        })
+      : NO_SELECTION,
+  parentSelected: props.parentWindowType
+    ? getSelection({
+        state,
+        windowType: props.parentWindowType,
+        viewId: props.parentDefaultViewId,
+      })
+    : NO_SELECTION,
 });
 
 export default connect(mapStateToProps, null, null, { withRef: true })(

--- a/src/components/app/SelectionAttributes.js
+++ b/src/components/app/SelectionAttributes.js
@@ -1,12 +1,12 @@
-import counterpart from "counterpart";
-import React, { Component } from "react";
-import { connect } from "react-redux";
+import counterpart from 'counterpart';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
 import {
   getViewAttributes,
   getViewAttributesLayout
-} from "../../actions/ViewAttributesActions";
-import RawWidget from "../widget/RawWidget";
+} from '../../actions/ViewAttributesActions';
+import RawWidget from '../widget/RawWidget';
 
 class SelectionAttributes extends Component {
   componentDidUpdate = prevProps => {
@@ -15,7 +15,7 @@ class SelectionAttributes extends Component {
       DLWrapperSetData,
       DLWrapperSetLayout,
       shouldNotUpdate,
-      supportAttribute
+      supportAttribute,
     } = this.props;
 
     if (shouldNotUpdate) {
@@ -42,7 +42,7 @@ class SelectionAttributes extends Component {
       viewId,
       selected,
       DLWrapperSetData,
-      DLWrapperSetLayout
+      DLWrapperSetLayout,
     } = this.props;
     getViewAttributesLayout(windowType, viewId, selected[0])
       .then(response => {
@@ -57,7 +57,7 @@ class SelectionAttributes extends Component {
 
   moveToDevice = e => {
     switch (e.key) {
-      case "Shift":
+      case 'Shift':
         e.preventDefault();
         //TO DO
         break;
@@ -69,7 +69,7 @@ class SelectionAttributes extends Component {
   };
 
   selectTable = () => {
-    document.getElementsByClassName("js-table")[0].focus();
+    document.getElementsByClassName('js-table')[0].focus();
   };
 
   render() {
@@ -88,7 +88,7 @@ class SelectionAttributes extends Component {
     return (
       <div className="js-not-unselect">
         <div className="attributes-selector-header">
-          {counterpart.translate("window.selectionAttributes.caption")}
+          {counterpart.translate('window.selectionAttributes.caption')}
         </div>
         <div tabIndex={1} className="attributes-selector-body js-attributes">
           {DLWrapperLayout &&
@@ -121,7 +121,7 @@ class SelectionAttributes extends Component {
             !DLWrapperLayout.length && (
               <i>
                 {counterpart.translate(
-                  "window.selectionAttributes.callToAction"
+                  'window.selectionAttributes.callToAction'
                 )}
               </i>
             )}

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -268,7 +268,6 @@ class Table extends Component {
   selectProduct = (id, idFocused, idFocusedDown) => {
     const { dispatch, type, disconnectFromState, tabInfo, viewId } = this.props;
     const { selected } = this.state;
-
     const newSelected = selected.concat([id]);
 
     this.setState({ selected: newSelected }, () => {


### PR DESCRIPTION
Regression bug. Looks like fixing #1394 broke loading attributes edit in HU editor. This PR introduces a mixed solution, using values from the store to trigger React's lifecycle events, but still has a fallback to update viewId (so that quickactions are properly displayed).

Related to #1623 #1625 #1631 .
Doesn't reintroduce #1394. 