### PR TITLE
Table cells edit mode

### DIFF
--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -7,14 +7,6 @@ import classnames from 'classnames';
 import MasterWidget from '../widget/MasterWidget';
 
 class TableCell extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      backdropLock: false,
-    };
-  }
-
   componentWillReceiveProps(nextProps) {
     const { widgetData, updateRow, readonly, rowId } = this.props;
     // We should avoid highlighting when whole row is exchanged (sorting)
@@ -31,25 +23,12 @@ class TableCell extends Component {
     }
   }
 
-  handleBackdropLock = state => {
-    this.setState({
-      backdropLock: !!state,
-    });
-  };
-
   handleClickOutside = e => {
-    const { onClickOutside, isEdited } = this.props;
-    const { backdropLock } = this.state;
+    const { onClickOutside } = this.props;
 
-    //We can handle click outside only if
-    //nested elements has no click oustide listening pending
-    if (!backdropLock && !isEdited) {
-      //it is important to change focus before collapsing to
-      //blur Widget field and patch data
-      this.cell && this.cell.focus();
+    this.cell && this.cell.focus();
 
-      onClickOutside(e);
-    }
+    onClickOutside(e);
   };
 
   static AMOUNT_FIELD_TYPES = ['Amount', 'CostPrice'];
@@ -215,7 +194,6 @@ class TableCell extends Component {
             tabId={mainTable ? null : tabId}
             noLabel={true}
             gridAlign={item.gridAlign}
-            handleBackdropLock={this.handleBackdropLock}
             listenOnKeys={listenOnKeys}
             listenOnKeysTrue={listenOnKeysTrue}
             listenOnKeysFalse={listenOnKeysFalse}

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -90,9 +90,7 @@ class RawWidget extends Component {
     } = this.props;
 
     enableOnClickOutside && enableOnClickOutside();
-
     dispatch(allowShortcut());
-
     handleBlur && handleBlur(this.willPatch(value));
 
     this.setState({
@@ -121,6 +119,7 @@ class RawWidget extends Component {
 
   handleKeyDown = (e, property, value, widgetType) => {
     if (e.key === 'Enter' && widgetType !== 'LongText') {
+      e.stopPropagation();
       this.handlePatch(property, value);
     }
   };


### PR DESCRIPTION
I was afraid I'd have to rewrite the whole TableItem/TableCell relation but removing some backdrop code seems to do the trick. It was supposed to prevent nested elements from closing, when the field is edited but it does work now anyways. Let me know if something is off.

Related to #1650 