### PR TITLE
Send PATCH when textarea is empty

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -100,7 +100,7 @@ class RawWidget extends Component {
 
     listenOnKeysTrue && listenOnKeysTrue();
 
-    if (widgetField && value) {
+    if (widgetField) {
       this.handlePatch(widgetField, value, id);
     }
   };


### PR DESCRIPTION
When all text is removed from the textarea, we should still send the PATCH request.