### PR TITLE
Fix saving attributes

### DIFF
--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -877,6 +877,7 @@ input[type=checkbox]:disabled, input[type=radio]:disabled {
 }
 
 .attributes-dropdown {
+    user-select: none;
     position: absolute;
     z-index: 50;
     margin-top:5px;

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -1,12 +1,19 @@
 import Moment from 'moment';
 import numeral from 'numeral';
 import React, { PureComponent } from 'react';
-import onClickOutside from 'react-onclickoutside';
 import classnames from 'classnames';
 
 import MasterWidget from '../widget/MasterWidget';
 
 class TableCell extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      backdropLock: false,
+    };
+  }
+
   componentWillReceiveProps(nextProps) {
     const { widgetData, updateRow, readonly, rowId } = this.props;
     // We should avoid highlighting when whole row is exchanged (sorting)
@@ -22,14 +29,6 @@ class TableCell extends PureComponent {
       updateRow();
     }
   }
-
-  handleClickOutside = e => {
-    const { onClickOutside } = this.props;
-
-    this.cell && this.cell.focus();
-
-    onClickOutside(e);
-  };
 
   static AMOUNT_FIELD_TYPES = ['Amount', 'CostPrice'];
   static AMOUNT_FIELD_FORMATS_BY_PRECISION = [
@@ -122,6 +121,19 @@ class TableCell extends PureComponent {
     }
   };
 
+  handleBackdropLock = state => {
+    this.setState(
+      {
+        backdropLock: !state,
+      },
+      () => {
+        if (!state) {
+          this.props.onClickOutside();
+        }
+      }
+    );
+  };
+
   render() {
     const {
       isEdited,
@@ -194,6 +206,7 @@ class TableCell extends PureComponent {
             tabId={mainTable ? null : tabId}
             noLabel={true}
             gridAlign={item.gridAlign}
+            handleBackdropLock={this.handleBackdropLock}
             listenOnKeys={listenOnKeys}
             listenOnKeysTrue={listenOnKeysTrue}
             listenOnKeysFalse={listenOnKeysFalse}
@@ -221,5 +234,5 @@ class TableCell extends PureComponent {
   }
 }
 
-export default onClickOutside(TableCell);
+export default TableCell;
 export { TableCell };

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -20,6 +20,23 @@ class TableItem extends PureComponent {
     };
   }
 
+  initPropertyEditor = fieldName => {
+    const { cols, fieldsByName } = this.props;
+
+    if (cols && fieldsByName) {
+      cols.map(item => {
+        const property = item.fields[0].field;
+        if (property === fieldName) {
+          const widgetData = this.prepareWidgetData(item);
+
+          if (widgetData) {
+            this.handleEditProperty(null, property, true, widgetData[0]);
+          }
+        }
+      });
+    }
+  };
+
   handleKeyDown = (e, property, widgetData) => {
     const { changeListenOnTrue } = this.props;
     const { listenOnKeys, edited } = this.state;
@@ -59,23 +76,6 @@ class TableItem extends PureComponent {
     const widgetData = item.fields.map(prop => fieldsByName[prop.field]);
 
     return widgetData;
-  };
-
-  initPropertyEditor = fieldName => {
-    const { cols, fieldsByName } = this.props;
-
-    if (cols && fieldsByName) {
-      cols.map(item => {
-        const property = item.fields[0].field;
-        if (property === fieldName) {
-          const widgetData = this.prepareWidgetData(item);
-
-          if (widgetData) {
-            this.handleEditProperty(null, property, true, widgetData[0]);
-          }
-        }
-      });
-    }
   };
 
   editProperty = (e, property, callback, item) => {
@@ -175,7 +175,7 @@ class TableItem extends PureComponent {
     } else {
       return (
         cols &&
-        cols.map((item, index) => {
+        cols.map(item => {
           const { supportZoomInto } = item.fields[0];
           const supportFieldEdit = mainTable && this.isAllowedFieldEdit(item);
           const property = item.fields[0].field;
@@ -226,7 +226,8 @@ class TableItem extends PureComponent {
                 mainTable,
                 viewId,
               }}
-              key={index}
+              key={`${rowId}-${property}`}
+              isRowSelected={this.props.isSelected}
               isEdited={isEditable || edited === property}
               onDoubleClick={e =>
                 this.handleEditProperty(e, property, true, widgetData[0])

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -167,9 +167,9 @@ class RawList extends PureComponent {
   };
 
   handleClickOutside() {
-    const { isToggled, onCloseDropdown, onBlur, selected } = this.props;
+    const { isFocused, onCloseDropdown, onBlur, selected } = this.props;
 
-    if (isToggled) {
+    if (isFocused) {
       this.setState(
         {
           selected: selected || null,


### PR DESCRIPTION
Fix to focus in table fields broke saving changes in attributes, as the corresponding onClickOutside of AttributesDropdown was never called. I've fixed this + removed the onClickOutside handler for the TableCell which is not needed anymore. All fields (quantity, dates, lists, attributes) look to be switching between the states properly now, and do a patch/complete request when unselected.

Haven't checked the Attributes in creating new address yet, but I don't think this should be affected.

Related to #1662 #1557 