### PR TITLE
Fix none option disappearing from list options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ dist
 # Coverage report
 .nyc_output
 coverage
+test_setup
+src/__tests__
+cypress
 
 package-lock.json

--- a/cypress/integration/business_partner_widgets_spec.js
+++ b/cypress/integration/business_partner_widgets_spec.js
@@ -1,0 +1,51 @@
+describe('Business partner window widgets test', function() {
+  before(function() {
+    cy.visit('/login');
+
+    cy.get('input[name=username]').type('kuba');
+    cy.get('input[name=password]').type('kuba1234{enter}');
+
+    // cy.get('button').click();
+
+    cy.url().should('not.include', '/login');
+    cy.get('.header-item').should('contain', 'Dashboard');
+  });
+
+  context('Tabs', function() {
+    beforeEach(function() {
+      cy.visit('/window/123/2156447');
+      cy.get('.header-breadcrumb-sitename')
+        .should('contain', 'Cypress Test Partner #1');
+    });
+
+    context('Vendor', function() {
+      it('Check if list widget works properly', function() {
+        cy.get('.nav-item[title="Vendor"]')
+          .click()
+          .get('.tab-content tbody td:nth-of-type(4)')
+          .dblclick()
+          .find('.input-dropdown-container')
+          .should('have.class', 'focused')
+          .click();
+
+        cy.get('.input-dropdown-list')
+          .should('exist')
+          .find('.input-dropdown-list-option')
+          .first()
+          .click();
+
+        cy.get('.tab-content tbody td:nth-of-type(4)')
+          .should('not.have.class', 'pulse-on')
+          .find('.input-editable')
+          .should('not.have.class', 'opened');
+
+        cy.get('.tab-content tbody td:nth-of-type(4)').click();
+
+        cy.get('.input-dropdown-list')
+          .should('exist')
+          .find('.input-dropdown-list-option')
+          .contains('none');
+      });
+    })
+  });
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
       "^.+\\.js$": "babel-jest"
     },
     "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/babel-polyfill/"
+      "<rootDir>/node_modules/babel-polyfill/",
+      "<rootDir>/node_modules/immutable"
     ]
   },
   "devDependencies": {

--- a/src/__tests__/components/widget/List/RawList.test.js
+++ b/src/__tests__/components/widget/List/RawList.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { List } from 'immutable';
+import RawList from '../../../../components/widget/List/RawList';
+import fixtures from '../../../../../test_setup/fixtures/raw_list.json';
+
+const createDummyProps = function(props, data) {
+  return {
+    onFocus: jest.fn(),
+    onBlur: jest.fn(),
+    onSelect: jest.fn(),
+    onOpenDropdown: jest.fn(),
+    onCloseDropdown: jest.fn(),
+    ...props,
+    list: List(data),
+  };
+};
+
+describe('RawList component', () => {
+  describe('rendering tests:', () => {
+    it('renders without errors', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.data1.widgetProps,
+          isFocused: true,
+        },
+        fixtures.data1.listData
+      );
+
+      const wrapper = mount(<RawList {...props} />);
+
+      expect(wrapper.html()).toContain('focused');
+      expect(wrapper.find('input').length).toBe(1);
+      expect(wrapper.find('input').html()).toContain(
+        'Testpreisliste Lieferanten'
+      );
+    });
+  });
+});

--- a/test_setup/fixtures/raw_list.json
+++ b/test_setup/fixtures/raw_list.json
@@ -1,0 +1,64 @@
+{
+  "data1": {
+    "widgetProps": {
+      "dataId": "2156441",
+      "entity": "window",
+      "defaultValue": "none",
+      "selected": {
+        "key": "2000835",
+        "caption": "Testpreisliste Lieferanten"
+      },
+      "properties": [
+        {
+          "field": "PO_PricingSystem_ID",
+          "source": "list",
+          "emptyText": "none",
+          "supportZoomInto": true
+        }
+      ],
+      "mandatory": false,
+      "windowType": "123",
+      "rowId": "2156441",
+      "tabId": "224",
+      "align": "left",
+      "updated": false,
+      "emptyText": "none",
+      "validStatus": {
+        "valid": true,
+        "initialValue": true,
+        "fieldName": "PO_PricingSystem_ID"
+      },
+      "filter": {},
+      "doNotOpenOnFocus": true,
+      "loading": false,
+      "list": [],
+      "isToggled": false,
+      "isFocused": false,
+      "eventTypes": [
+        "mousedown",
+        "touchstart"
+      ],
+      "outsideClickIgnoreClass": "ignore-react-onclickoutside",
+      "preventDefault": false,
+      "stopPropagation": false
+    },
+    "listData": [
+      {
+        "key": "2000284",
+        "caption": "Divers"
+      },
+      {
+        "key": "2000838",
+        "caption": "Lagerkonferenz"
+      },
+      {
+        "key": "2000835",
+        "caption": "Testpreisliste Lieferanten"
+      },
+      {
+        "key": "2000836",
+        "caption": "Testpreisliste Verpackung"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
It was foolish to use data from props instead of local copy which contains the default option as well.

Added basic cypress e2e test for list widget in table, and basic automated test. To be able to write proper automated test we first need to figure out how to render Tethered components with enzyme.

Relates to #1669 