### PR TITLE
Barcode scanner widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "moment": "~2.16.0",
     "numeral": "^2.0.6",
     "prop-types": "^15.5.6",
+    "quagga": "^0.12.1",
     "query-string": "^5.0.1",
     "react": "^16.2.0",
     "react-addons-css-transition-group": "~15.6.2",

--- a/src/assets/css/overlayfield.css
+++ b/src/assets/css/overlayfield.css
@@ -28,3 +28,19 @@
     font-size: 30px;
     text-align: center;
 }
+
+.barcode-scanner-widget {
+    display: flex;
+}
+
+.scanner-wrapper {
+    
+}
+
+.scanning-result {
+
+}
+
+.scanning-result .form-control-label {
+
+}

--- a/src/assets/css/overlayfield.css
+++ b/src/assets/css/overlayfield.css
@@ -31,16 +31,36 @@
 
 .barcode-scanner-widget {
     display: flex;
+    flex-direction: column;
+    background-color: white;
+    border: solid 1px #C9D5DC;
 }
 
 .scanner-wrapper {
-    
+    width: 640px;
+}
+
+.scanner-wrapper .drawingBuffer {
+    position: absolute;
+    top: 0;
+    left:0;
+}
+
+.scanner-window video {
+    max-width: 100%;
+    width: 100%;
 }
 
 .scanning-result {
-
+    margin-bottom: 20px;
 }
 
-.scanning-result .form-control-label {
-
+.scanning-result .label {
+    font-size: 18px;
 }
+
+.scanner-controls {
+    margin: 20px 0;
+}
+
+

--- a/src/assets/css/overlayfield.css
+++ b/src/assets/css/overlayfield.css
@@ -9,6 +9,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow-y: scroll;
+}
+
+@media (min-width: $breakpoint-md){
+    overflow-y: auto;
 }
 
 .overlay-field .form-group {
@@ -36,14 +41,21 @@
     border: solid 1px #C9D5DC;
 }
 
-.scanner-wrapper {
-    width: 640px;
-}
-
 .scanner-wrapper .drawingBuffer {
     position: absolute;
     top: 0;
     left:0;
+}
+
+.scanner-window {
+    width: 320px;
+}
+
+@media (min-width: $breakpoint-md){
+    .scanner-window {
+        width: 640px;
+        float: none;
+    }
 }
 
 .scanner-window video {

--- a/src/components/app/BarcodeScanner.js
+++ b/src/components/app/BarcodeScanner.js
@@ -48,6 +48,7 @@ export default class BarcodeScanner extends Component {
       },
       err => {
         if (err) {
+          // eslint-disable-next-line no-console
           return console.log(err);
         }
         Quagga.start();

--- a/src/components/app/BarcodeScanner.js
+++ b/src/components/app/BarcodeScanner.js
@@ -7,12 +7,14 @@ const BarcodeScannerResult = function({ result, onSelect }) {
     return null;
   }
   return (
-    <button
-      className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
-      onClick={() => onSelect(result)}
-    >
-      {result.codeResult.code}
-    </button>
+    <div className="col-sm-9">
+      <button
+        className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
+        onClick={() => onSelect(result)}
+      >
+        {result.codeResult.code}
+      </button>
+    </div>
   );
 };
 
@@ -28,8 +30,8 @@ export default class BarcodeScanner extends Component {
         inputStream: {
           type: 'LiveStream',
           constraints: {
-            width: 640,
-            height: 480,
+            width: 1280,
+            height: 720,
             facingMode: 'environment',
           },
         },
@@ -38,7 +40,7 @@ export default class BarcodeScanner extends Component {
           halfSample: true,
         },
         numOfWorkers: 4,
-        frequency: 10,
+        frequency: 5,
         decoder: {
           readers: ['ean_reader'],
         },
@@ -60,20 +62,20 @@ export default class BarcodeScanner extends Component {
   }
 
   _handleStop = () => {
-    Quagga.stop();
+    Quagga.offDetected(this._onDetected);
 
     this.props.onClose();
-  }
+  };
 
   _handleStart = () => {
     this.props.onReset();
-    Quagga.start();
-  }
+    Quagga.onDetected(this._onDetected);
+  };
 
   _onDetected = result => {
-    Quagga.stop();
+    Quagga.offDetected(this._onDetected);
     this.props.onDetected(result);
-  }
+  };
 
   _onProcessed(result) {
     const drawingCtx = Quagga.canvas.ctx.overlay;
@@ -115,13 +117,19 @@ export default class BarcodeScanner extends Component {
 
   render() {
     return (
-      <div className="scanner-wrapper">
-        <div id="interactive" className="viewport scanner-window"/>
-        <div className="scanner-controls">
-          <button onClick={this._handleStart}>
+      <div className="row scanner-wrapper">
+        <div id="interactive" className="col-sm-12 viewport scanner-window" />
+        <div className="col-sm-12 scanner-controls">
+          <button
+            className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
+            onClick={this._handleStart}
+          >
             Scan again
           </button>
-          <button onClick={this._handleStop}>
+          <button
+            className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
+            onClick={this._handleStop}
+          >
             Close
           </button>
         </div>

--- a/src/components/app/BarcodeScanner.js
+++ b/src/components/app/BarcodeScanner.js
@@ -1,0 +1,103 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Quagga from 'quagga';
+
+const BarcodeScannerResult = function() {
+  const result = this.props.result;
+
+  if (!result) {
+    return null;
+  }
+  return (
+    <li>
+      {result.codeResult.code} [{result.codeResult.format}]
+    </li>
+  );
+};
+
+export default class BarcodeScanner extends Component {
+  componentDidMount() {
+    Quagga.init(
+      {
+        inputStream: {
+          type: 'LiveStream',
+          constraints: {
+            width: 640,
+            height: 480,
+            facingMode: 'environment',
+          },
+        },
+        locator: {
+          patchSize: 'medium',
+          halfSample: true,
+        },
+        numOfWorkers: 4,
+        frequency: 10,
+        decoder: {
+          readers: ['code_128_reader'],
+        },
+        locate: true,
+      },
+      err => {
+        if (err) {
+          return console.log(err);
+        }
+        Quagga.start();
+      }
+    );
+    Quagga.onDetected(this._onDetected);
+    Quagga.onProcessed(this._onProcessed);
+  }
+
+  componentWillUnmount() {
+    Quagga.offDetected(this._onDetected);
+  }
+
+  _onDetected(result) {
+    console.log('ondetected')
+    this.props.onDetected(result);
+  }
+
+  _onProcessed(result) {
+    const drawingCtx = Quagga.canvas.ctx.overlay;
+    const drawingCanvas = Quagga.canvas.dom.overlay;
+
+    if (result) {
+      if (result.boxes) {
+        drawingCtx.clearRect(
+          0,
+          0,
+          parseInt(drawingCanvas.getAttribute('width')),
+          parseInt(drawingCanvas.getAttribute('height'))
+        );
+        result.boxes.filter(box => box !== result.box).forEach(box => {
+          Quagga.ImageDebug.drawPath(box, { x: 0, y: 1 }, drawingCtx, {
+            color: 'green',
+            lineWidth: 2,
+          });
+        });
+      }
+
+      if (result.box) {
+        Quagga.ImageDebug.drawPath(result.box, { x: 0, y: 1 }, drawingCtx, {
+          color: '#00F',
+          lineWidth: 2,
+        });
+      }
+
+      if (result.codeResult && result.codeResult.code) {
+        Quagga.ImageDebug.drawPath(result.line, { x: 'x', y: 'y' }, drawingCtx, { color: 'red', lineWidth: 3 });
+      }
+    }
+  }
+
+  render() {
+    return <div id="interactive" className="viewport"/>;
+  }
+}
+
+BarcodeScanner.propTypes = {
+  onDetected: PropTypes.func.isRequired,
+};
+
+export { BarcodeScannerResult };

--- a/src/components/app/BarcodeScanner.js
+++ b/src/components/app/BarcodeScanner.js
@@ -7,7 +7,7 @@ const BarcodeScannerResult = function({ result, onSelect }) {
     return null;
   }
   return (
-    <div className="col-sm-9">
+    <div className="col-xs-9">
       <button
         className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
         onClick={() => onSelect(result)}
@@ -54,7 +54,10 @@ export default class BarcodeScanner extends Component {
       }
     );
     Quagga.onDetected(this._onDetected);
-    Quagga.onProcessed(this._onProcessed);
+
+    if (this.props.debug) {
+      Quagga.onProcessed(this._onProcessed);
+    }
   }
 
   componentWillUnmount() {
@@ -116,11 +119,14 @@ export default class BarcodeScanner extends Component {
   }
 
   render() {
+    const { result } = this.props;
+
     return (
       <div className="row scanner-wrapper">
         <div id="interactive" className="col-sm-12 viewport scanner-window" />
         <div className="col-sm-12 scanner-controls">
           <button
+            disabled={!result}
             className="btn btn-filter btn-meta-outline-secondary btn-distance btn-s"
             onClick={this._handleStart}
           >
@@ -139,6 +145,7 @@ export default class BarcodeScanner extends Component {
 }
 
 BarcodeScanner.propTypes = {
+  result: PropTypes.object,
   onDetected: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   onReset: PropTypes.func.isRequired,

--- a/src/components/app/OverlayField.js
+++ b/src/components/app/OverlayField.js
@@ -32,6 +32,7 @@ class OverlayField extends Component {
   _scanBarcode = val => {
     this.setState({
       scanning: typeof val !== 'undefined' ? val : !this.state.scanning,
+      result: null,
       barcodeSelected: null,
     });
   };
@@ -42,11 +43,10 @@ class OverlayField extends Component {
     });
   };
 
-  selectBarcode = (result) => {
-    const barcode = result || null;
-
+  selectBarcode = result => {
     this.setState({
-      barcodeSelected: result,
+      barcodeSelected: result.codeResult.code,
+      scanning: false,
     });
   };
 
@@ -62,16 +62,15 @@ class OverlayField extends Component {
       if (elem.caption === 'Barcode') {
         captionElement = (
           <button
-            className="btn btn-sm btn-block btn-meta-success"
-            onClick={this._scanBarcode}
+            className="btn btn-sm btn-meta-success"
+            onClick={() => this._scanBarcode(true)}
           >
-            {/*{counterpart.translate('barcodescan.caption')}*/}
             Scan using camera
           </button>
         );
 
         if (barcodeSelected) {
-
+          widgetData[0].value = barcodeSelected;
         }
       }
 
@@ -96,20 +95,22 @@ class OverlayField extends Component {
     const { result } = this.state;
 
     return (
-      <div className="barcode-scanner-widget">
-        <BarcodeScanner
-          onDetected={this._onBarcodeDetected}
-          onClose={() => this._scanBarcode(false)}
-          onReset={this.selectBarcode}
-        />
-        <div className="scanning-result">
-          <span className="form-control-label col-sm-3 ">
-            Barcode
-          </span>
-          <BarcodeScannerResult
-            result={result}
-            onSelect={(result) => this.selectBarcode(result)}
+      <div className="row barcode-scanner-widget">
+        <div className="col-sm-12">
+          <BarcodeScanner
+            onDetected={this._onBarcodeDetected}
+            onClose={() => this._scanBarcode(false)}
+            onReset={() => this._scanBarcode(true)}
           />
+          <div className="row scanning-result">
+            <span className="label col-sm-2">
+              Barcode
+            </span>
+            <BarcodeScannerResult
+              result={result}
+              onSelect={result => this.selectBarcode(result)}
+            />
+          </div>
         </div>
       </div>
     );

--- a/src/components/app/OverlayField.js
+++ b/src/components/app/OverlayField.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import counterpart from 'counterpart';
 
 import MasterWidget from '../widget/MasterWidget';
 import RawWidget from '../widget/RawWidget';
@@ -106,9 +105,7 @@ class OverlayField extends Component {
             onReset={() => this._scanBarcode(true)}
           />
           <div className="row scanning-result">
-            <span className="label col-xs-3 col-sm-2">
-              Barcode
-            </span>
+            <span className="label col-xs-3 col-sm-2">Barcode</span>
             <BarcodeScannerResult
               result={result}
               onSelect={result => this.selectBarcode(result)}
@@ -117,7 +114,7 @@ class OverlayField extends Component {
         </div>
       </div>
     );
-  }
+  };
 
   renderParameters = layout => {
     const {

--- a/src/components/app/OverlayField.js
+++ b/src/components/app/OverlayField.js
@@ -26,6 +26,11 @@ class OverlayField extends Component {
       case 'Escape':
         closeOverlay();
         break;
+      default:
+        this.setState({
+          barcodeSelected: null,
+        });
+        break;
     }
   };
 
@@ -68,10 +73,6 @@ class OverlayField extends Component {
             Scan using camera
           </button>
         );
-
-        if (barcodeSelected) {
-          widgetData[0].value = barcodeSelected;
-        }
       }
 
       return (
@@ -85,6 +86,7 @@ class OverlayField extends Component {
           disabled={disabled}
           autoFocus={id === 0}
           captionElement={captionElement}
+          data={barcodeSelected || undefined}
           {...elem}
         />
       );
@@ -98,12 +100,13 @@ class OverlayField extends Component {
       <div className="row barcode-scanner-widget">
         <div className="col-sm-12">
           <BarcodeScanner
+            result={result}
             onDetected={this._onBarcodeDetected}
             onClose={() => this._scanBarcode(false)}
             onReset={() => this._scanBarcode(true)}
           />
           <div className="row scanning-result">
-            <span className="label col-sm-2">
+            <span className="label col-xs-3 col-sm-2">
               Barcode
             </span>
             <BarcodeScannerResult

--- a/src/components/app/OverlayField.js
+++ b/src/components/app/OverlayField.js
@@ -2,10 +2,17 @@ import React, { Component } from 'react';
 
 import MasterWidget from '../widget/MasterWidget';
 import RawWidget from '../widget/RawWidget';
+import BarcodeScanner, { BarcodeScannerResult } from './BarcodeScanner';
+import Result from './BarcodeScanner'
 
 class OverlayField extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      scanning: false,
+      results: [],
+    };
   }
 
   handleKeyDown = e => {
@@ -21,24 +28,54 @@ class OverlayField extends Component {
     }
   };
 
+  _scan = () => {
+    this.setState({
+      scanning: !this.state.scanning,
+    });
+  };
+
+  _onDetected = result => {
+    this.setState({
+      results: this.state.results.concat([result]),
+    });
+  };
+
   renderElements = (layout, data, type) => {
     const { disabled } = this.props;
     const elements = layout.elements;
     return elements.map((elem, id) => {
       const widgetData = elem.fields.map(item => data[item.field] || -1);
-      return (
-        <MasterWidget
-          entity="process"
-          key={'element' + id}
-          windowType={type}
-          dataId={layout.pinstanceId}
-          widgetData={widgetData}
-          isModal={true}
-          disabled={disabled}
-          autoFocus={id === 0}
-          {...elem}
-        />
-      );
+
+      if (elem.caption === 'Barcode') {
+        console.log('barcodescanner !')
+        return (
+          <div key={id}>
+            <button onClick={this._scan}>{this.state.scanning ? 'Stop' : 'Start'}</button>
+            <ul className="results">
+              {this.state.results.map(result => (
+                <BarcodeScannerResult key={result.codeResult.code} result={result} />
+              ))}
+            </ul>
+            {this.state.scanning ? (
+              <BarcodeScanner onDetected={this._onDetected} />
+            ) : null}
+          </div>
+        );
+      } else {
+        return (
+          <MasterWidget
+            entity="process"
+            key={'element' + id}
+            windowType={type}
+            dataId={layout.pinstanceId}
+            widgetData={widgetData}
+            isModal={true}
+            disabled={disabled}
+            autoFocus={id === 0}
+            {...elem}
+          />
+        );
+      }
     });
   };
 

--- a/src/components/app/OverlayField.js
+++ b/src/components/app/OverlayField.js
@@ -126,11 +126,30 @@ class OverlayField extends Component {
       handleChange,
       captionValue,
     } = this.props;
+    const { barcodeSelected } = this.state;
     const parameters = layout.parameters;
     return parameters.map((item, index) => {
+      let captionElement = null;
+
+      if (item.parameterName === 'Barcode') {
+        captionElement = (
+          <button
+            className="btn btn-sm btn-meta-success"
+            onClick={() => this._scanBarcode(true)}
+          >
+            Scan using camera
+          </button>
+        );
+      }
+
+      if (barcodeSelected) {
+        item.value = barcodeSelected;
+      }
+
       return (
         <RawWidget
           defaultValue={captionValue}
+          captionElement={captionElement}
           entity="documentView"
           subentity="filter"
           subentityId={layout.filterId}
@@ -167,6 +186,8 @@ class OverlayField extends Component {
     if (scanning) {
       renderedContent = this.renderScanner();
     } else {
+      // TODO: Why sometimes it's wrapped in MasterWidget, and other
+      // times it's not ? Needs refactoring.
       if (filter) {
         renderedContent = this.renderParameters(layout);
       } else if (!filter && layout && layout.elements) {

--- a/src/components/widget/MasterWidget.js
+++ b/src/components/widget/MasterWidget.js
@@ -16,9 +16,9 @@ class MasterWidget extends Component {
   };
 
   componentDidMount() {
-    const { widgetData } = this.props;
+    const { data, widgetData } = this.props;
     this.setState({
-      data: widgetData[0].value,
+      data: data || widgetData[0].value,
     });
   }
 
@@ -214,7 +214,6 @@ class MasterWidget extends Component {
 
   render() {
     const { handleBackdropLock } = this.props;
-
     const { updated, data } = this.state;
     const handleFocusFn = handleBackdropLock ? handleBackdropLock : () => {};
 

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -824,6 +824,7 @@ class RawWidget extends Component {
   render() {
     const {
       caption,
+      captionElement,
       fields,
       type,
       noLabel,
@@ -873,6 +874,7 @@ class RawWidget extends Component {
           widgetFieldsName
         }
       >
+        {captionElement || null}
         {!noLabel &&
           caption && (
             <div

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -119,7 +119,6 @@ class RawWidget extends Component {
 
   handleKeyDown = (e, property, value, widgetType) => {
     if (e.key === 'Enter' && widgetType !== 'LongText') {
-      e.stopPropagation();
       this.handlePatch(property, value);
     }
   };


### PR DESCRIPTION
Widget uses https://github.com/serratus/quaggaJS to allow reading barcodes with the built-in camera. Works for desktop and mobile devices and supports `EAN` codes. If we want other codes to work as well, we need to add a dropdown for selection. There are some false positives, as neither the cameras, focusing and image recognition work great when using the browser and the built-in camera.

Relates to #1609 

Here's how it works : 

1. Trigger opening barcode widget from the app

![screen shot 2018-03-14 at 1 23 56 am](https://user-images.githubusercontent.com/513460/37377073-28359146-2728-11e8-8941-13ec75706139.png)

2. Notice the new button. We can still use the input field as previously. After clicking the button, and giving the browser permissions to use our camera we see the widget. The `Scan again` button is used for resetting the scanner. It is disabled when nothing was scanned yet.

![screen shot 2018-03-14 at 1 25 32 am](https://user-images.githubusercontent.com/513460/37377092-479368b0-2728-11e8-9c06-b491a64304b0.png)

3. After a successful scan we can either scan again, or click the button with scanned number.

![screen shot 2018-03-14 at 1 26 22 am](https://user-images.githubusercontent.com/513460/37377104-61ddf2ee-2728-11e8-8a47-379c7a41dd88.png)

4. It then will be used in the input field

![screen shot 2018-03-14 at 1 26 40 am](https://user-images.githubusercontent.com/513460/37377069-1fe61ccc-2728-11e8-8826-d5f2701a8d2a.png)


**TODO**
I don't know how we handle translations, and I believe we have some texts here that need to be translatable.