### PR TITLE
Patch date selection field on each blur

### DIFF
--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -99,6 +99,7 @@ export function closeFilterBox() {
   };
 }
 
+// TODO: Name collides with the value in the state
 export function allowOutsideClick() {
   return {
     type: ALLOW_OUTSIDE_CLICK,

--- a/src/components/widget/DatePicker.js
+++ b/src/components/widget/DatePicker.js
@@ -93,9 +93,19 @@ class DatePicker extends Component {
     );
   };
 
+  focusInput = () => {
+    this.inputElement && this.inputElement.focus();
+  };
+
   renderInput = ({ className, ...props }) => (
     <div className={className}>
-      <input className="form-control" {...props} />
+      <input
+        {...props}
+        className="form-control"
+        ref={input => {
+          this.inputElement = input;
+        }}
+      />
     </div>
   );
 
@@ -110,6 +120,7 @@ class DatePicker extends Component {
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           open={this.state.open}
+          onFocusInput={this.focusInput}
           {...this.props}
         />
         <i className="meta-icon-calendar" key={0} />

--- a/src/components/widget/DatePicker.js
+++ b/src/components/widget/DatePicker.js
@@ -2,20 +2,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import TetheredDateTime from './TetheredDateTime';
+import onClickOutside from 'react-onclickoutside';
 import { addNotification } from '../../actions/AppActions';
 import {
   allowOutsideClick,
   disableOutsideClick,
 } from '../../actions/WindowActions';
-
-const propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  handleBackdropLock: PropTypes.func,
-  patch: PropTypes.func,
-  field: PropTypes.string,
-  value: PropTypes.any,
-  isOpenDatePicker: PropTypes.bool,
-};
 
 class DatePicker extends Component {
   constructor(props) {
@@ -38,12 +30,17 @@ class DatePicker extends Component {
 
   handleBlur = date => {
     const { patch, handleBackdropLock, dispatch, field } = this.props;
-    const { cache } = this.state;
+    const { cache, open } = this.state;
+
+    if (!open) {
+      return;
+    }
 
     try {
       if (
+        date &&
         JSON.stringify(cache) !==
-        (date !== '' ? JSON.stringify(date && date.toDate()) : '')
+          (date !== '' ? JSON.stringify(date && date.toDate()) : '')
       ) {
         patch(date);
       }
@@ -76,7 +73,12 @@ class DatePicker extends Component {
   };
 
   handleClickOutside = () => {
-    this.handleClose();
+    const { open } = this.state;
+
+    if (!open) {
+      return;
+    }
+    this.handleBlur(this.picker.state.selectedDate);
   };
 
   handleKeydown = e => {
@@ -107,6 +109,7 @@ class DatePicker extends Component {
           renderInput={this.renderInput}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
+          open={this.state.open}
           {...this.props}
         />
         <i className="meta-icon-calendar" key={0} />
@@ -115,6 +118,13 @@ class DatePicker extends Component {
   }
 }
 
-DatePicker.propTypes = propTypes;
+DatePicker.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  handleBackdropLock: PropTypes.func,
+  patch: PropTypes.func,
+  field: PropTypes.string,
+  value: PropTypes.any,
+  isOpenDatePicker: PropTypes.bool,
+};
 
-export default connect()(DatePicker);
+export default connect()(onClickOutside(DatePicker));

--- a/src/components/widget/TetheredDateTime.js
+++ b/src/components/widget/TetheredDateTime.js
@@ -2,18 +2,16 @@ import React from 'react';
 import DateTime from 'react-datetime';
 import CalendarContainer from 'react-datetime/src/CalendarContainer';
 import TetherComponent from 'react-tether';
+import classnames from 'classnames';
 
-export default class TetheredDateTime extends DateTime {
+// TODO: This monkeypatching that's happening here has to go.
+class TetheredDateTime extends DateTime {
   render() {
-    const { open } = this.state;
-    let className =
-      'rdt' +
-      (this.props.className
-        ? Array.isArray(this.props.className)
-          ? ' ' + this.props.className.join(' ')
-          : ' ' + this.props.className
-        : '');
-    let children = [];
+    const { open } = this.props;
+    let className = classnames('rdt', this.props.className, {
+      rdtStatic: !this.props.input,
+    });
+    const children = [];
 
     if (this.props.input) {
       const props = {
@@ -26,15 +24,9 @@ export default class TetheredDateTime extends DateTime {
         ...this.props.inputProps,
       };
 
-      if (this.props.renderInput) {
-        children = [
-          <div key="i">{this.props.renderInput(props, this.openCalendar)}</div>,
-        ];
-      } else {
-        children = [<input key="i" {...props} />];
-      }
-    } else {
-      className += ' rdtStatic';
+      children.push(
+        <div key="i">{this.props.renderInput(props, this.openCalendar)}</div>
+      );
     }
 
     return (
@@ -54,11 +46,10 @@ export default class TetheredDateTime extends DateTime {
         >
           {children}
           {open && (
-            <div className="rdtPicker">
+            <div className="ignore-react-onclickoutside rdtPicker">
               <CalendarContainer
                 view={this.state.currentView}
                 viewProps={this.getComponentProps()}
-                onClickOutside={this.handleClickOutside}
               />
             </div>
           )}
@@ -67,3 +58,5 @@ export default class TetheredDateTime extends DateTime {
     );
   }
 }
+
+export default TetheredDateTime;

--- a/src/components/widget/TetheredDateTime.js
+++ b/src/components/widget/TetheredDateTime.js
@@ -6,6 +6,23 @@ import classnames from 'classnames';
 
 // TODO: This monkeypatching that's happening here has to go.
 class TetheredDateTime extends DateTime {
+  onInputKey = e => {
+    if (
+      (e.key === 'Tab' && this.props.closeOnTab) ||
+      e.key === 'Enter' ||
+      e.key === 'Escape'
+    ) {
+      this.closeCalendar();
+    }
+  };
+
+  updateSelectedDate = (e, close) => {
+    if (this.props.onFocusInput) {
+      this.props.onFocusInput();
+    }
+    return super.updateSelectedDate(e, close);
+  };
+
   render() {
     const { open } = this.props;
     let className = classnames('rdt', this.props.className, {
@@ -23,10 +40,9 @@ class TetheredDateTime extends DateTime {
         value: this.state.inputValue,
         ...this.props.inputProps,
       };
+      const input = this.props.renderInput(props, this.openCalendar);
 
-      children.push(
-        <div key="i">{this.props.renderInput(props, this.openCalendar)}</div>
-      );
+      children.push(<div key="i">{input}</div>);
     }
 
     return (


### PR DESCRIPTION
Currently the DatePicker component is a bit of a mess. There are a lot of unused props, obsolete code and it's hard to follow what's controlling showing/hiding the date picker widget.
Now picker shows up when the input is clicked, and hides either on clicking outside of the input/widget, or after clicking tab/enter/esc key. Thanks to that we can support the use-case from #1660 when user opens the widget but changes the date with keyboard.