### PR TITLE
Fix lists after last merge

### DIFF
--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -674,7 +674,7 @@ input:checked + .input-slider:before {
         }
 
         &&.focused {
-            border-bottom-color: #4b5b64;
+            border-bottom-color: $input-focused-border;
         }
 
         &&.opened {
@@ -734,7 +734,8 @@ input:checked + .input-slider:before {
     flex: 1;
 
     &&.focused {
-        border-bottom: 1px solid #C9D5DC;
+        border-bottom: 1px solid $input-focused-border;
+        padding-bottom: .2rem;
     }
 
     &&.input-icon {

--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -734,8 +734,6 @@ input:checked + .input-slider:before {
     flex: 1;
 
     &&.focused {
-        border-bottom: 1px solid $input-focused-border;
-        padding-bottom: .2rem;
     }
 
     &&.input-icon {

--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -39,5 +39,7 @@ $tooltip-border-color: #d5e5f0;
 
 $brand-icon-off: #D8D8D8;
 
+$input-focused-border: #4b5b64;
+
 $breakpoint-md: 991px;
 $breakpoint: 543px;

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -6,10 +6,14 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SelectionDropdown from '../SelectionDropdown';
 
+/*
+ * We want the selected option to be displayed first,
+ * so in case it has an index other than 0 we will move it
+ * to the top of the list
+ */
 const setSelectedValue = function(dropdownList, selected) {
   const changedValues = {};
   let idx = 0;
-
   let selectedOption = selected;
 
   if (selected) {
@@ -171,9 +175,10 @@ class RawList extends PureComponent {
   };
 
   handleCancel = () => {
-    this.props.disableAutofocus();
+    const { disableAutofocus, onCloseDropdown } = this.props;
+    disableAutofocus && disableAutofocus();
     this.handleBlur();
-    this.props.onCloseDropdown();
+    onCloseDropdown && onCloseDropdown();
   };
 
   handleKeyDown = e => {
@@ -186,6 +191,7 @@ class RawList extends PureComponent {
     } else if (e.key === 'ArrowDown') {
       if (!isToggled) {
         e.preventDefault();
+        e.stopPropagation();
         onOpenDropdown();
       }
     }

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -176,12 +176,17 @@ class RawList extends PureComponent {
     this.props.onCloseDropdown();
   };
 
-  handleKeyDown = event => {
-    const { onSelect, list, readonly } = this.props;
+  handleKeyDown = e => {
+    const { onSelect, list, readonly, isToggled, onOpenDropdown } = this.props;
 
-    if (event.key === 'Tab') {
+    if (e.key === 'Tab') {
       if (list.size === 0 && !readonly) {
         onSelect(null);
+      }
+    } else if (e.key === 'ArrowDown') {
+      if (!isToggled) {
+        e.preventDefault();
+        onOpenDropdown();
       }
     }
   };

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { is, List } from 'immutable';
+import onClickOutside from 'react-onclickoutside';
 import TetherComponent from 'react-tether';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -129,6 +130,22 @@ class RawList extends PureComponent {
     this.dropdown.focus();
     onOpenDropdown();
   };
+
+  handleClickOutside() {
+    const { isFocused, onCloseDropdown, onBlur, selected } = this.props;
+
+    if (isFocused) {
+      this.setState(
+        {
+          selected: selected || null,
+        },
+        () => {
+          onCloseDropdown();
+          onBlur();
+        }
+      );
+    }
+  }
 
   handleSelect = selected => {
     const { onSelect, onCloseDropdown } = this.props;
@@ -347,4 +364,4 @@ RawList.propTypes = {
   onCloseDropdown: PropTypes.func.isRequired,
 };
 
-export default RawList;
+export default onClickOutside(RawList);

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -22,7 +22,7 @@ class Lookup extends Component {
       fireDropdownList: false,
       autofocusDisabled: false,
       isDropdownListOpen: false,
-      isFocused: false,
+      isFocused: {},
     };
   }
 
@@ -173,19 +173,29 @@ class Lookup extends Component {
     });
   };
 
-  handleFocus = () => {
+  handleFocus = fieldName => {
     this.setState({
-      isFocused: true,
+      isFocused: {
+        ...this.state.isFocused,
+        [`${fieldName}`]: true,
+      }
     });
     this.props.onFocus();
   };
 
-  handleBlur = () => {
+  handleBlur = fieldName => {
     this.setState({
-      isFocused: false,
+      isFocused: {
+        ...this.state.isFocused,
+        [`${fieldName}`]: false,
+      }
     });
     this.props.onHandleBlur();
   };
+
+  getFocused = fieldName => {
+    return !!this.state.isFocused[fieldName];
+  }
 
   disableAutofocus = () => {
     this.setState({
@@ -384,12 +394,12 @@ class Lookup extends Component {
 
               return (
                 <div
-                  key={index}
+                  key={item.field}
                   className={classnames(
-                    'raw-lookup-wrapper raw-lookup-wrapper-bcg ',
+                    'raw-lookup-wrapper raw-lookup-wrapper-bcg',
                     {
                       'raw-lookup-disabled': disabled || readonly,
-                      focused: isFocused,
+                      focused: this.getFocused(item.field),
                     }
                   )}
                 >
@@ -413,8 +423,8 @@ class Lookup extends Component {
                     setNextProperty={this.setNextProperty}
                     disableAutofocus={this.disableAutofocus}
                     enableAutofocus={this.enableAutofocus}
-                    onFocus={this.handleFocus}
-                    onHandleBlur={this.handleBlur}
+                    onFocus={() => this.handleFocus(item.field)}
+                    onHandleBlur={() => this.handleBlur(item.field)}
                     {...{
                       dataId,
                       entity,

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -178,7 +178,7 @@ class Lookup extends Component {
       isFocused: {
         ...this.state.isFocused,
         [`${fieldName}`]: true,
-      }
+      },
     });
     this.props.onFocus();
   };
@@ -188,14 +188,14 @@ class Lookup extends Component {
       isFocused: {
         ...this.state.isFocused,
         [`${fieldName}`]: false,
-      }
+      },
     });
     this.props.onHandleBlur();
   };
 
   getFocused = fieldName => {
     return !!this.state.isFocused[fieldName];
-  }
+  };
 
   disableAutofocus = () => {
     this.setState({
@@ -278,7 +278,6 @@ class Lookup extends Component {
       localClearing,
       fireDropdownList,
       autofocusDisabled,
-      isFocused,
     } = this.state;
 
     this.linkedList = [];

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -218,22 +218,22 @@ class RawLookup extends Component {
   handleBlur = () => {
     const { onHandleBlur } = this.props;
 
-    this.setState({
-      isFocused: false,
-    },
-    () => {
-      this.props.onDropdownListToggle(false);
-      onHandleBlur && onHandleBlur();
-    });
-
-    
+    this.setState(
+      {
+        isFocused: false,
+      },
+      () => {
+        this.props.onDropdownListToggle(false);
+        onHandleBlur && onHandleBlur();
+      }
+    );
   };
 
   handleFocus = () => {
     this.setState({
       isFocused: true,
     });
-  }
+  };
 
   handleChange = (handleChangeOnFocus, allowEmpty) => {
     const {
@@ -374,7 +374,14 @@ class RawLookup extends Component {
       isOpen,
     } = this.props;
 
-    const { isInputEmpty, list, loading, selected, forceEmpty, isFocused } = this.state;
+    const {
+      isInputEmpty,
+      list,
+      loading,
+      selected,
+      forceEmpty,
+      isFocused,
+    } = this.state;
 
     return (
       <TetherComponent
@@ -391,13 +398,11 @@ class RawLookup extends Component {
         ]}
       >
         <div
-          className={classnames('raw-lookup-wrapper raw-lookup-wrapper-bcg',
-            {
-              'raw-lookup-disabled': disabled,
-              'input-disabled': readonly,
-              focused: isFocused,
-            }
-          )}
+          className={classnames('raw-lookup-wrapper raw-lookup-wrapper-bcg', {
+            'raw-lookup-disabled': disabled,
+            'input-disabled': readonly,
+            focused: isFocused,
+          })}
           ref={ref => (this.wrapper = ref)}
         >
           <div className={'input-dropdown input-block'}>

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import TetherComponent from 'react-tether';
 import ReactDOM from 'react-dom';
+import classnames from 'classnames';
 
 import { autocompleteRequest } from '../../../actions/GenericActions';
 import { getViewAttributeTypeahead } from '../../../actions/ViewAttributesActions';
@@ -22,6 +23,7 @@ class RawLookup extends Component {
       loading: false,
       oldValue: '',
       shouldBeFocused: true,
+      isFocused: false,
     };
   }
 
@@ -216,10 +218,22 @@ class RawLookup extends Component {
   handleBlur = () => {
     const { onHandleBlur } = this.props;
 
-    this.props.onDropdownListToggle(false);
+    this.setState({
+      isFocused: false,
+    },
+    () => {
+      this.props.onDropdownListToggle(false);
+      onHandleBlur && onHandleBlur();
+    });
 
-    onHandleBlur && onHandleBlur();
+    
   };
+
+  handleFocus = () => {
+    this.setState({
+      isFocused: true,
+    });
+  }
 
   handleChange = (handleChangeOnFocus, allowEmpty) => {
     const {
@@ -360,7 +374,7 @@ class RawLookup extends Component {
       isOpen,
     } = this.props;
 
-    const { isInputEmpty, list, loading, selected, forceEmpty } = this.state;
+    const { isInputEmpty, list, loading, selected, forceEmpty, isFocused } = this.state;
 
     return (
       <TetherComponent
@@ -377,11 +391,13 @@ class RawLookup extends Component {
         ]}
       >
         <div
-          className={
-            'raw-lookup-wrapper raw-lookup-wrapper-bcg' +
-            (disabled ? ' raw-lookup-disabled' : '') +
-            (readonly ? ' input-disabled' : '')
-          }
+          className={classnames('raw-lookup-wrapper raw-lookup-wrapper-bcg',
+            {
+              'raw-lookup-disabled': disabled,
+              'input-disabled': readonly,
+              focused: isFocused,
+            }
+          )}
           ref={ref => (this.wrapper = ref)}
         >
           <div className={'input-dropdown input-block'}>
@@ -398,6 +414,7 @@ class RawLookup extends Component {
                 placeholder={placeholder}
                 onChange={this.handleChange}
                 onBlur={this.handleBlur}
+                onFocus={this.handleFocus}
               />
             </div>
           </div>

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
+import classnames from 'classnames';
 
 export default class SelectionDropdown extends Component {
   static propTypes = {
@@ -95,7 +96,8 @@ export default class SelectionDropdown extends Component {
     this.ignoreNextMouseEnter = true;
 
     const { selected, options, onChange } = this.props;
-
+    const size = this.size(options);
+    const selectedNew = this.get(options, index);
     let index = options.indexOf(selected);
 
     if (up) {
@@ -104,15 +106,11 @@ export default class SelectionDropdown extends Component {
       index++;
     }
 
-    const size = this.size(options);
-
     if (index < 0) {
       index = 0;
     } else if (index >= size) {
       index = size - 1;
     }
-
-    const selectedNew = this.get(options, index);
 
     if (selectedNew === selected) {
       return;
@@ -133,19 +131,15 @@ export default class SelectionDropdown extends Component {
       case 'ArrowUp':
         navigate(true);
         break;
-
       case 'ArrowDown':
         navigate(false);
         break;
-
       case 'Escape':
         onCancel();
         break;
-
       case 'Enter':
         onSelect(selected);
         break;
-
       default:
         return;
     }
@@ -174,7 +168,6 @@ export default class SelectionDropdown extends Component {
     }
 
     this.ignoreOption = null;
-
     this.props.onChange(option);
   };
 
@@ -194,17 +187,16 @@ export default class SelectionDropdown extends Component {
     const { selected } = this.props;
     const { key, caption } = option;
 
-    const classNames = ['input-dropdown-list-option'];
-
-    if (option === selected) {
-      classNames.push('input-dropdown-list-option-key-on');
-    }
-
     return (
       <div
         ref={ref => this.optionToRef.set(option, ref)}
         key={`${key}${caption}`}
-        className={classNames.join(' ')}
+        className={classnames(
+          'input-dropdown-list-option ignore-react-onclickoutside',
+          {
+            'input-dropdown-list-option-key-on': option === selected,
+          }
+        )}
         onMouseEnter={() => this.handleMouseEnter(option)}
         onMouseDown={() => this.handleMouseDown(option)}
       >
@@ -229,7 +221,6 @@ export default class SelectionDropdown extends Component {
 
   render() {
     const { options, width, loading, forceEmpty } = this.props;
-
     const empty = this.size(options) === 0;
 
     return (

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -97,7 +97,6 @@ export default class SelectionDropdown extends Component {
 
     const { selected, options, onChange } = this.props;
     const size = this.size(options);
-    const selectedNew = this.get(options, index);
     let index = options.indexOf(selected);
 
     if (up) {
@@ -111,6 +110,8 @@ export default class SelectionDropdown extends Component {
     } else if (index >= size) {
       index = size - 1;
     }
+
+    const selectedNew = this.get(options, index);
 
     if (selectedNew === selected) {
       return;
@@ -129,9 +130,11 @@ export default class SelectionDropdown extends Component {
 
     switch (event.key) {
       case 'ArrowUp':
+        event.preventDefault();
         navigate(true);
         break;
       case 'ArrowDown':
+        event.preventDefault();
         navigate(false);
         break;
       case 'Escape':

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -15,19 +15,7 @@ export default class SelectionDropdown extends Component {
         size: PropTypes.number.isRequired,
       }),
     ]).isRequired,
-    selected: (props, propName) => {
-      const selected = props[propName];
-
-      if ([null, undefined].includes(selected)) {
-        return;
-      }
-
-      if (!props.options.includes(selected)) {
-        return new Error(
-          `${propName} must be one of options. ${propName}: ${selected}`
-        );
-      }
-    },
+    selected: PropTypes.object,
     empty: PropTypes.node,
     forceEmpty: PropTypes.bool,
     width: PropTypes.number.isRequired,
@@ -83,7 +71,6 @@ export default class SelectionDropdown extends Component {
       top: topMax,
       bottom: bottomMax,
     } = this.wrapper.getBoundingClientRect();
-
     const { top, bottom } = element.getBoundingClientRect();
 
     if (top < topMax || bottom > bottomMax) {


### PR DESCRIPTION
Bunch of different things stopped working after last refactoring. We need to be more diligent next time, as it should be easily noticeable. Also none of my comment from the refactor PR was ever addressed.

Fixed:
- closing the dropdown on mouse selection
- opening the dropdown with arrow down when the field is focused
- weird props error
- improved focused state indication

