### PR TITLE
Fix opening dropdown in table

### DIFF
--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -126,8 +126,8 @@ class TableCell extends PureComponent {
       type,
       rowId,
       tabId,
-      onDoubleClick,
-      onKeyDown,
+      handleDoubleClick,
+      handleKeyDown,
       readonly,
       updatedRow,
       tabIndex,
@@ -159,8 +159,8 @@ class TableCell extends PureComponent {
       <td
         tabIndex={tabIndex}
         ref={c => (this.cell = c)}
-        onDoubleClick={readonly ? null : onDoubleClick}
-        onKeyDown={onKeyDown}
+        onDoubleClick={readonly ? null : handleDoubleClick}
+        onKeyDown={handleKeyDown}
         onContextMenu={handleRightClick}
         className={classnames(
           {

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -94,7 +94,7 @@ class TableItem extends PureComponent {
             )[0];
 
             if (elem) {
-              elem.select();
+              elem.focus();
             }
 
             const disabled = document.activeElement.querySelector(
@@ -231,7 +231,7 @@ class TableItem extends PureComponent {
                 key={`${rowId}-${property}`}
                 isRowSelected={this.props.isSelected}
                 isEdited={isEditable || edited === property}
-                onDoubleClick={e =>
+                handleDoubleClick={e =>
                   this.handleEditProperty(e, property, true, widgetData[0])
                 }
                 onClickOutside={e => {
@@ -242,7 +242,9 @@ class TableItem extends PureComponent {
                 onCellChange={onItemChange}
                 updatedRow={updatedRow || newRow}
                 updateRow={this.updateRow}
-                onKeyDown={e => this.handleKeyDown(e, property, widgetData[0])}
+                handleKeyDown={e =>
+                  this.handleKeyDown(e, property, widgetData[0])
+                }
                 listenOnKeysTrue={this.listenOnKeysTrue}
                 listenOnKeysFalse={this.listenOnKeysFalse}
                 closeTableField={e => this.closeTableField(e)}

--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -51,13 +51,13 @@ class ListWidget extends Component {
   componentDidUpdate(prevProps) {
     const { isInputEmpty } = this.props;
     const { initialFocus, defaultValue, doNotOpenOnFocus } = this.props;
-    const { autoFocus, isFocused, list } = this.state;
+    const { autoFocus, isToggled, list } = this.state;
 
     if (isInputEmpty && prevProps.isInputEmpty !== isInputEmpty) {
       this.previousValue = '';
     }
 
-    if (prevProps.autoFocus !== autoFocus && !isFocused) {
+    if (prevProps.autoFocus !== autoFocus && !isToggled) {
       if (autoFocus) {
         this.handleFocus();
         !doNotOpenOnFocus && list && list.size > 1 && this.activate();

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -66,6 +66,7 @@ class RawList extends PureComponent {
       selected,
       autoFocus,
       emptyText,
+      isFocused,
     } = this.props;
 
     let dropdownList = this.state.dropdownList;
@@ -118,7 +119,7 @@ class RawList extends PureComponent {
           ...changedValues,
         },
         () => {
-          autoFocus && this.dropdown.focus();
+          autoFocus && !isFocused && this.dropdown.focus();
         }
       );
     }
@@ -129,10 +130,14 @@ class RawList extends PureComponent {
    * on focus.
    */
   handleClick = () => {
-    const { onOpenDropdown } = this.props;
+    const { onOpenDropdown, isToggled, onCloseDropdown } = this.props;
 
-    this.dropdown.focus();
-    onOpenDropdown();
+    if (!isToggled) {
+      this.dropdown.focus();
+      onOpenDropdown();
+    } else {
+      onCloseDropdown();
+    }
   };
 
   handleClickOutside() {
@@ -281,7 +286,6 @@ class RawList extends PureComponent {
           })}
           tabIndex={tabIndex ? tabIndex : 0}
           onFocus={readonly ? null : onFocus}
-          onBlur={this.props.onBlur}
           onClick={readonly ? null : this.handleClick}
           onKeyDown={this.handleKeyDown}
           onKeyUp={this.handleKeyUp}


### PR DESCRIPTION
When double clicking table cell with a dropdown field, it will now wait for another click to open the list with options. The same goes for normal lists with dropdown. This way users can open/close dropdowns by clicking on the input which feels much more natural.

Related to #1712 