### PR TITLE
Fix errors in profile section

### DIFF
--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -5,6 +5,7 @@ import SockJs from 'sockjs-client';
 import currentDevice from 'current-device';
 import Stomp from 'stompjs/lib/stomp.min.js';
 import Moment from 'moment';
+import { Set } from 'immutable';
 
 import {
   ACTIVATE_TAB,
@@ -536,7 +537,7 @@ export function initWindow(windowType, docId, tabId, rowId = null, isAdvanced) {
               includedTabsInfo: {},
               scope: 'master',
               saveStatus: { saved: true },
-              standardActions: {},
+              standardActions: Set(),
               validStatus: {},
             })
           );

--- a/src/reducers/windowHandler.js
+++ b/src/reducers/windowHandler.js
@@ -1,5 +1,5 @@
 import update from 'immutability-helper';
-import { Map, List } from 'immutable';
+import { Map, List, Set } from 'immutable';
 
 import {
   ACTIVATE_TAB,
@@ -189,7 +189,7 @@ export default function windowHandler(state = initialState, action) {
           layout: {},
           rowData: Map(),
           saveStatus: action.saveStatus,
-          standardActions: new Set(action.standardActions),
+          standardActions: Set(action.standardActions),
           validStatus: action.validStatus,
           includedTabsInfo: action.includedTabsInfo,
           websocket: action.websocket,
@@ -297,7 +297,7 @@ export default function windowHandler(state = initialState, action) {
           },
         },
       });
-    case UPDATE_DATA_PROPERTY: {
+    case UPDATE_DATA_PROPERTY:
       let value;
 
       if (typeof action.value === 'string') {
@@ -305,7 +305,7 @@ export default function windowHandler(state = initialState, action) {
       } else if (action.property === 'standardActions') {
         // TODO: Evaluate if standardActions of type Set
         // is worth this extra check
-        value = new Set(action.value);
+        value = Set(action.value);
       } else {
         value = Object.assign(
           {},
@@ -321,7 +321,6 @@ export default function windowHandler(state = initialState, action) {
           },
         },
       });
-    }
 
     case UPDATE_ROW_FIELD_PROPERTY: {
       const { scope, tabid, rowid, property } = action;

--- a/src/reducers/windowHandler.js
+++ b/src/reducers/windowHandler.js
@@ -297,7 +297,7 @@ export default function windowHandler(state = initialState, action) {
           },
         },
       });
-    case UPDATE_DATA_PROPERTY:
+    case UPDATE_DATA_PROPERTY: {
       let value;
 
       if (typeof action.value === 'string') {
@@ -321,7 +321,7 @@ export default function windowHandler(state = initialState, action) {
           },
         },
       });
-
+    }
     case UPDATE_ROW_FIELD_PROPERTY: {
       const { scope, tabid, rowid, property } = action;
       const scState = state[scope];


### PR DESCRIPTION
When debugging some profile-related bug I got errors in the console because Set object was not yet available when the app was initialized. Used `immutablejs`'s Set instead.

This is the page that was throwing the error: /window/53100/2188223. It should just show 404 instead.

![screen shot 2018-03-29 at 7 57 44 pm](https://user-images.githubusercontent.com/513460/38105142-861c1068-338b-11e8-8039-c71ecec4c884.png)
