### PR TITLE
Fix switching fields with tabs in address modal

### DIFF
--- a/src/components/widget/Attributes/Attributes.js
+++ b/src/components/widget/Attributes/Attributes.js
@@ -245,4 +245,5 @@ export default class Attributes extends Component {
 Attributes.propTypes = {
   patch: PropTypes.func.isRequired,
   handleBackdropLock: PropTypes.func,
+  isModal: PropTypes.bool,
 };

--- a/src/components/widget/Attributes/AttributesDropdown.js
+++ b/src/components/widget/Attributes/AttributesDropdown.js
@@ -62,6 +62,7 @@ class AttributesDropdown extends Component {
       attrId,
       disableOnClickOutside,
       enableOnClickOutside,
+      isModal,
     } = this.props;
 
     if (layout) {
@@ -83,6 +84,7 @@ class AttributesDropdown extends Component {
             disableOnClickOutside={disableOnClickOutside}
             enableOnClickOutside={enableOnClickOutside}
             tabIndex={tabIndex}
+            isModal={isModal}
           />
         );
       });
@@ -100,6 +102,7 @@ class AttributesDropdown extends Component {
 
 AttributesDropdown.propTypes = {
   tabIndex: PropTypes.number,
+  isModal: PropTypes.bool,
   data: PropTypes.object.isRequired,
   attributeType: PropTypes.string.isRequired,
   handleChange: PropTypes.func.isRequired,

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -754,6 +754,7 @@ class RawWidget extends Component {
             tabIndex={tabIndex}
             autoFocus={autoFocus}
             readonly={readonly}
+            isModal={isModal}
           />
         );
       case 'Image':


### PR DESCRIPTION
When opened in modal the attributes widget would not allow switching between the fields with tab.

#1725  