### PR TITLE
Use localized hardcoded date formats

### DIFF
--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -16,8 +16,8 @@ export const AMOUNT_FIELD_FORMATS_BY_PRECISION = [
 ];
 export const DATE_FIELD_TYPES = ['Date', 'DateTime', 'Time'];
 export const DATE_FIELD_FORMATS = {
-  Date: 'DD.MM.YYYY',
-  DateTime: 'DD.MM.YYYY HH:mm:ss',
-  Time: 'HH:mm:ss',
+  Date: 'l',
+  DateTime: 'l LTS',
+  Time: 'LTS',
 };
 export const TIME_FIELD_TYPES = ['Time'];


### PR DESCRIPTION
`Moment.js` provides default localized formats we can use in TableCell's helper functions instead of ones defined by us.

Related to #1567 