### PR TITLE
Fix closing the BarcodeScanner widget

### DIFF
--- a/src/components/widget/BarcodeScanner/BarcodeScanner.js
+++ b/src/components/widget/BarcodeScanner/BarcodeScanner.js
@@ -44,7 +44,7 @@ export default class BarcodeScanner extends Component {
     Quagga.offDetected(this._onDetected);
   }
 
-  _handleStop = skipCloseCallback => {
+  _handleStop = () => {
     Quagga.offDetected(this._onDetected);
     Quagga.stop();
 

--- a/src/components/widget/BarcodeScanner/BarcodeScanner.js
+++ b/src/components/widget/BarcodeScanner/BarcodeScanner.js
@@ -48,9 +48,7 @@ export default class BarcodeScanner extends Component {
     Quagga.offDetected(this._onDetected);
     Quagga.stop();
 
-    if (!skipCloseCallback) {
-      this.props.onClose();
-    }
+    this.props.onClose();
   };
 
   _onDetected = result => {


### PR DESCRIPTION
After clicking the close crosshair it stays open. #1681 