### PR TITLE
Fix clicks on table cells

### DIFF
--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -161,7 +161,10 @@ class TableCell extends PureComponent {
       <td
         tabIndex={modalVisible ? -1 : tabIndex}
         ref={c => (this.cell = c)}
-        onDoubleClick={readonly ? null : handleDoubleClick}
+        onDoubleClick={e => {
+          if (isEdited) e.stopPropagation();
+          if (!readonly) handleDoubleClick(e);
+        }}
         onKeyDown={handleKeyDown}
         onContextMenu={handleRightClick}
         className={classnames(

--- a/src/components/table/TableContextMenu.js
+++ b/src/components/table/TableContextMenu.js
@@ -86,16 +86,9 @@ class TableContextMenu extends Component {
     dispatch(setFilter(filter, refType));
 
     window.open(
-      '/window/' +
-        refType +
-        '?refType=' +
-        type +
-        '&refId=' +
-        docId +
-        '&refTabId=' +
-        tabId +
-        '&refRowIds=' +
-        JSON.stringify(selected || []),
+      `/window/${refType}?refType=${type}&refId=${docId}&refTabId=${tabId}&refRowIds=${JSON.stringify(
+        selected || []
+      )}`,
       '_blank'
     );
   };


### PR DESCRIPTION
The doubleclick on table cell was never invoked. I changed it so that when field is edited, we call the cell's method, but when it's not edited we propagate it further (which atm means calling DocumentList's method that redirects to the document details page).

Related to #1274 

**Ticket also mentions translations which are not added atm.**
Do we want to wait for those, or create a more general ticket for adding the missing translations ?