### PR TITLE
Patch date field on double clicks

### DIFF
--- a/src/components/Window.js
+++ b/src/components/Window.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 
 import Table from '../components/table/Table';
@@ -7,7 +7,7 @@ import MasterWidget from '../components/widget/MasterWidget';
 import Dropzone from './Dropzone';
 import Separator from './Separator';
 
-class Window extends Component {
+class Window extends PureComponent {
   constructor(props) {
     super(props);
 

--- a/src/components/widget/DatePicker.js
+++ b/src/components/widget/DatePicker.js
@@ -87,7 +87,7 @@ class DatePicker extends Component {
 
   renderDay = (props, currentDate) => {
     return (
-      <td {...props} onDoubleClick={() => this.handleClose()}>
+      <td {...props} onDoubleClick={() => this.handleBlur(currentDate)}>
         {currentDate.date()}
       </td>
     );
@@ -121,6 +121,7 @@ class DatePicker extends Component {
           onFocus={this.handleFocus}
           open={this.state.open}
           onFocusInput={this.focusInput}
+          closeOnSelect={false}
           {...this.props}
         />
         <i className="meta-icon-calendar" key={0} />

--- a/src/components/widget/TetheredDateTime.js
+++ b/src/components/widget/TetheredDateTime.js
@@ -3,9 +3,19 @@ import DateTime from 'react-datetime';
 import CalendarContainer from 'react-datetime/src/CalendarContainer';
 import TetherComponent from 'react-tether';
 import classnames from 'classnames';
+import { debounce } from 'lodash';
 
 // TODO: This monkeypatching that's happening here has to go at some point.
 class TetheredDateTime extends DateTime {
+  constructor(props) {
+    super(props);
+
+    this.updateSelectedDate = debounce(this.updateSelectedDate, 300, {
+      leading: true,
+      trailing: false,
+    });
+  }
+
   onInputKey = e => {
     if (
       (e.key === 'Tab' && this.props.closeOnTab) ||
@@ -20,6 +30,7 @@ class TetheredDateTime extends DateTime {
     if (this.props.onFocusInput) {
       this.props.onFocusInput();
     }
+
     return super.updateSelectedDate(e, close);
   };
 

--- a/src/components/widget/TetheredDateTime.js
+++ b/src/components/widget/TetheredDateTime.js
@@ -4,7 +4,7 @@ import CalendarContainer from 'react-datetime/src/CalendarContainer';
 import TetherComponent from 'react-tether';
 import classnames from 'classnames';
 
-// TODO: This monkeypatching that's happening here has to go.
+// TODO: This monkeypatching that's happening here has to go at some point.
 class TetheredDateTime extends DateTime {
   onInputKey = e => {
     if (


### PR DESCRIPTION
When double clicking in Date selector, we should close the widget and patch the field.

Related to #1755 