### PR TITLE
Fix lookup fields

### DIFF
--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { List } from 'immutable';
 import { findKey } from 'lodash';
 
+import { arePropTypesIdentical } from '../../../utils';
 import { dropdownRequest } from '../../../actions/GenericActions';
 import { getViewAttributeDropdown } from '../../../actions/ViewAttributesActions';
 import RawList from './RawList';
@@ -23,6 +24,9 @@ class ListWidget extends Component {
       listFocused: false,
     };
   }
+
+  shouldComponentUpdate = nextProps =>
+    !arePropTypesIdentical(nextProps, this.props);
 
   componentDidMount() {
     const { defaultValue } = this.props;

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -321,18 +321,20 @@ class Lookup extends Component {
             // TODO: This is really not how we should be doing this. Backend should send
             // us info which fields are usable with barcode scanner
             showBarcodeScannerBtn = item.field === 'M_LocatorTo_ID';
+
             const disabled = isInputEmpty && index !== 0;
             const itemByProperty = getItemsByProperty(
               defaultValue,
               'field',
               item.field
             )[0];
+
             if (
               item.source === 'lookup' ||
               item.widgetType === 'Lookup' ||
               (itemByProperty && itemByProperty.widgetType === 'Lookup')
             ) {
-              let defaultValue = itemByProperty.value;
+              let defaultValue = isInputEmpty ? null : itemByProperty.value;
 
               if (barcodeSelected) {
                 defaultValue = { caption: barcodeSelected };
@@ -394,6 +396,7 @@ class Lookup extends Component {
               const isFirstProperty = index === 0;
               const isCurrentProperty =
                 item.field === property && !autofocusDisabled;
+              let defaultValue = isInputEmpty ? null : itemByProperty.value;
 
               return (
                 <div
@@ -419,9 +422,7 @@ class Lookup extends Component {
                     doNotOpenOnFocus={false}
                     properties={[item]}
                     mainProperty={[item]}
-                    defaultValue={
-                      itemByProperty.value ? itemByProperty.value : ''
-                    }
+                    defaultValue={defaultValue ? defaultValue : ''}
                     initialFocus={isFirstProperty ? initialFocus : false}
                     blur={!property ? true : false}
                     setNextProperty={this.setNextProperty}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,8 @@ import App from './containers/App';
 
 // if (process.env.NODE_ENV !== 'production') {
 //   const {whyDidYouUpdate} = require('why-did-you-update')
-//   whyDidYouUpdate(React);
+//   // whyDidYouUpdate(React);
+//   whyDidYouUpdate(React, { include: [/ListWidget/] });
 // }
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,7 +17,10 @@ export const getQueryString = query =>
 
 export const arePropTypesIdentical = (nextProps, currentProps) => {
   for (const key of Object.keys(nextProps)) {
-    if (typeof nextProps[key] !== typeof currentProps[key]) {
+    const nextType = typeof nextProps[key];
+    const currentType = typeof currentProps[key];
+
+    if (nextType !== currentType) {
       return false;
     }
   }


### PR DESCRIPTION
When clicking the clear button on a nested lookup field, default values are still displayed even though only the first field is editable.