### PR TITLE
Fix [alt] + q/+ shortcuts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
         "cy": true,
         "context": true,
         "Cypress": true,
-        "before": true
+        "before": true,
+        "document": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/babel-polyfill/",
       "<rootDir>/node_modules/immutable"
-    ]
+    ],
+    "testEnvironment": "jsdom"
   },
   "devDependencies": {
     "@storybook/react": "^3.2.13",

--- a/src/__tests__/components/keyshortcuts/ShortcutProvider.test.js
+++ b/src/__tests__/components/keyshortcuts/ShortcutProvider.test.js
@@ -187,6 +187,34 @@ describe('ShortcutProvider', () => {
   });
 
   describe('handleKeyDown', () => {
+    beforeEach(() => {
+      const listeners = [];
+      const listenerAPI = {
+        addEventListener: (event, handler) => {
+          listeners.push([event, handler]);
+        },
+        removeEventListener: (event, handler) => {
+          const indices = [];
+          let i = 0;
+
+          for (const listener of listeners) {
+            if (listener[0] === event && listener[1] === handler) {
+              indices.push(i);
+            }
+
+            i++;
+          }
+
+          for (const index of indices.reverse()) {
+            listeners.splice(index, 1);
+          }
+        },
+      };
+
+      global.document = listenerAPI;
+      global.window = listenerAPI;
+    });
+
     it('should return when key is not defined', () => {
       const shortcutProvider = new ShortcutProvider();
       shortcutProvider.props = { hotkeys: {} };

--- a/src/components/keyshortcuts/ShortcutProvider.js
+++ b/src/components/keyshortcuts/ShortcutProvider.js
@@ -101,7 +101,7 @@ export default class ShortcutProvider extends Component {
   handleKeyDown = event => {
     const _key = codeToKey[event.keyCode];
     const key = _key && _key.toUpperCase();
-    const activeNode = document.activeElement;
+    const activeNode = document ? document.activeElement : null;
 
     if (!key) {
       return;
@@ -136,7 +136,8 @@ export default class ShortcutProvider extends Component {
       !(serializedSequence in hotkeys) ||
       // some shortcuts should be disabled
       // when input field is focused (for typing)
-      (activeNode.nodeName === 'INPUT' &&
+      (activeNode &&
+        activeNode.nodeName === 'INPUT' &&
         disabledWithFocus.indexOf(serializedSequence) > -1)
     ) {
       return;

--- a/src/components/keyshortcuts/ShortcutProvider.js
+++ b/src/components/keyshortcuts/ShortcutProvider.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import { disabledWithFocus } from '../../shortcuts/keymap';
 
 const codeToKey = {
   8: 'Backspace',
@@ -100,8 +101,14 @@ export default class ShortcutProvider extends Component {
   handleKeyDown = event => {
     const _key = codeToKey[event.keyCode];
     const key = _key && _key.toUpperCase();
+    const activeNode = document.activeElement;
 
-    if (!key) {
+    // some shortcuts should be disabled
+    // when input field is focused (for typing)
+    if (
+      !key ||
+      (activeNode.nodeName === 'INPUT' && disabledWithFocus.indexOf(key) > -1)
+    ) {
       return;
     }
 

--- a/src/components/keyshortcuts/ShortcutProvider.js
+++ b/src/components/keyshortcuts/ShortcutProvider.js
@@ -136,7 +136,8 @@ export default class ShortcutProvider extends Component {
       !(serializedSequence in hotkeys) ||
       // some shortcuts should be disabled
       // when input field is focused (for typing)
-      (activeNode.nodeName === 'INPUT' && disabledWithFocus.indexOf(serializedSequence) > -1)
+      (activeNode.nodeName === 'INPUT' &&
+        disabledWithFocus.indexOf(serializedSequence) > -1)
     ) {
       return;
     }

--- a/src/components/keyshortcuts/ShortcutProvider.js
+++ b/src/components/keyshortcuts/ShortcutProvider.js
@@ -103,12 +103,7 @@ export default class ShortcutProvider extends Component {
     const key = _key && _key.toUpperCase();
     const activeNode = document.activeElement;
 
-    // some shortcuts should be disabled
-    // when input field is focused (for typing)
-    if (
-      !key ||
-      (activeNode.nodeName === 'INPUT' && disabledWithFocus.indexOf(key) > -1)
-    ) {
+    if (!key) {
       return;
     }
 
@@ -137,7 +132,12 @@ export default class ShortcutProvider extends Component {
       .replace(/\s/, 'Spacebar')
       .toUpperCase();
 
-    if (!(serializedSequence in hotkeys)) {
+    if (
+      !(serializedSequence in hotkeys) ||
+      // some shortcuts should be disabled
+      // when input field is focused (for typing)
+      (activeNode.nodeName === 'INPUT' && disabledWithFocus.indexOf(serializedSequence) > -1)
+    ) {
       return;
     }
 

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -56,7 +56,7 @@ class RawWidget extends Component {
    * DOM element outside of it's parent's tree.
    */
   focus = () => {
-    const { dispatch, handleFocus, disableOnClickOutside, entity } = this.props;
+    const { handleFocus, disableOnClickOutside, entity } = this.props;
     const { rawWidget } = this;
 
     if (rawWidget && rawWidget.focus) {

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -39,13 +39,14 @@ class RawWidget extends Component {
 
   componentDidMount() {
     const { autoFocus, textSelected } = this.props;
+    const { rawWidget } = this;
 
-    if (this.rawWidget && autoFocus) {
-      this.rawWidget.focus();
+    if (rawWidget && autoFocus) {
+      rawWidget.focus();
     }
 
     if (textSelected) {
-      this.rawWidget.select();
+      rawWidget.select();
     }
   }
 
@@ -56,12 +57,11 @@ class RawWidget extends Component {
    */
   focus = () => {
     const { dispatch, handleFocus, disableOnClickOutside, entity } = this.props;
+    const { rawWidget } = this;
 
-    if (this.rawWidget && this.rawWidget.focus) {
-      this.rawWidget.focus();
+    if (rawWidget && rawWidget.focus) {
+      rawWidget.focus();
     }
-
-    dispatch(disableShortcut());
 
     // don't disable onclickoutside for the attributes widget
     if (entity !== 'pattribute') {

--- a/src/shortcuts/keymap.js
+++ b/src/shortcuts/keymap.js
@@ -56,10 +56,7 @@ const keymaps = {
 
 // Combinations that should be disabled when focus is in an input field,
 // which means user is typing or we focused the field automatically
-const disabledWithFocus = [
-  keymaps.EXPAND_INDENT,
-  keymaps.COLLAPSE_INDENT,
-];
+const disabledWithFocus = [keymaps.EXPAND_INDENT, keymaps.COLLAPSE_INDENT];
 
 export { disabledWithFocus };
 export default keymaps;

--- a/src/shortcuts/keymap.js
+++ b/src/shortcuts/keymap.js
@@ -1,6 +1,6 @@
 const mod = 'Alt';
 
-export default {
+const keymaps = {
   /* Global context */
   OPEN_ACTIONS_MENU: `${mod}+1`,
   OPEN_NAVIGATION_MENU: `${mod}+2`,
@@ -53,3 +53,13 @@ export default {
   APPLY: `${mod}+Enter`,
   CANCEL: 'Escape',
 };
+
+// Combinations that should be disabled when focus is in an input field,
+// which means user is typing or we focused the field automatically
+const disabledWithFocus = [
+  keymaps.EXPAND_INDENT,
+  keymaps.COLLAPSE_INDENT,
+];
+
+export { disabledWithFocus };
+export default keymaps;

--- a/test_setup/jestSetup.js
+++ b/test_setup/jestSetup.js
@@ -22,3 +22,7 @@ global.config = {
   API_URL: 'http://api.test.url',
   WS_URL: 'http://ws.test.url',
 };
+
+Object.defineProperty(document, 'activeElement', {
+  value: function() { return {nodeName: 'FOO'} },
+});


### PR DESCRIPTION
Lists were disabling shortcuts on focus (as all the other widgets). Now we're disabling some shortcuts when focus is in an input field (which means user is typing, or we've autofocused this field) instead.

#1756 
#1540 