### PR TITLE
Don't reload DocumentList views after changing attributes

### DIFF
--- a/src/actions/GenericActions.js
+++ b/src/actions/GenericActions.js
@@ -311,14 +311,7 @@ export function attachmentsRequest(entity, docType, docId) {
 
 export function processNewRecord(entity, docType, docId) {
   return axios.get(
-    config.API_URL +
-      '/' +
-      entity +
-      '/' +
-      docType +
-      '/' +
-      docId +
-      '/processNewRecord'
+    `${config.API_URL}/${entity}/${docType}/${docId}/processNewRecord`
   );
 }
 

--- a/src/actions/ViewAttributesActions.js
+++ b/src/actions/ViewAttributesActions.js
@@ -68,15 +68,7 @@ export function getViewAttributeTypeahead(
  */
 export function getViewAttributes(windowId, viewId, rowId) {
   return axios.get(
-    config.API_URL +
-      '/documentView' +
-      '/' +
-      windowId +
-      '/' +
-      viewId +
-      '/' +
-      rowId +
-      '/attributes'
+    `${config.API_URL}/documentView/${windowId}/${viewId}/${rowId}/attributes`
   );
 }
 
@@ -84,15 +76,7 @@ export function patchViewAttributes(windowId, viewId, rowId, property, value) {
   const payload = createPatchRequestPayload(property, value);
 
   return axios.patch(
-    config.API_URL +
-      '/documentView' +
-      '/' +
-      windowId +
-      '/' +
-      viewId +
-      '/' +
-      rowId +
-      '/attributes',
+    `${config.API_URL}/documentView/${windowId}/${viewId}/${rowId}/attributes`,
     payload
   );
 }

--- a/src/components/DataLayoutWrapper.js
+++ b/src/components/DataLayoutWrapper.js
@@ -1,4 +1,5 @@
 import React, { cloneElement, Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { patchViewAttributes } from '../actions/ViewAttributesActions';
@@ -36,8 +37,10 @@ class DataLayoutWrapper extends Component {
   };
 
   handlePatch = (prop, value, cb) => {
-    const { windowType: windowId, viewId } = this.props;
+    const { windowType: windowId, viewId, onRowEdited } = this.props;
     const { dataId: rowId } = this.state;
+
+    onRowEdited && onRowEdited(true);
 
     /*eslint-disable */
     patchViewAttributes(windowId, viewId, rowId, prop, value).then(({ data }) => {
@@ -58,10 +61,10 @@ class DataLayoutWrapper extends Component {
           });
         }
       }
+
+      cb && cb();
     });
     /*eslint-enable */
-
-    cb && cb();
   };
 
   setData = (data, dataId, cb) => {
@@ -94,7 +97,7 @@ class DataLayoutWrapper extends Component {
     const { layout, data } = this.state;
     const { children, className } = this.props;
 
-    // sometimes it's a number, and React complaints about wrong type
+    // sometimes it's a number, and React complains about wrong type
     const dataId = this.state.dataId + '';
 
     return (
@@ -116,5 +119,9 @@ class DataLayoutWrapper extends Component {
     );
   }
 }
+
+DataLayoutWrapper.propTypes = {
+  onRowEdited: PropTypes.func,
+};
 
 export default connect()(DataLayoutWrapper);

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -96,6 +96,10 @@ class DocumentList extends Component {
 
       isShowIncluded: false,
       hasShowIncluded: false,
+
+      // in some scenarios we don't want to reload table data
+      // after edit, as it triggers request, collapses rows and looses selection
+      rowEdited: false,
     };
 
     this.fetchLayoutAndData();
@@ -609,6 +613,12 @@ class DocumentList extends Component {
 
   // END OF MANAGING SORT, PAGINATION, FILTERS -------------------------------
 
+  setTableRowEdited = val => {
+    this.setState({
+      rowEdited: val,
+    });
+  };
+
   adjustWidth = () => {
     const widthIdx =
       this.state.toggleWidth + 1 === PANEL_WIDTHS.length
@@ -724,6 +734,7 @@ class DocumentList extends Component {
       refreshSelection,
       supportAttribute,
       toggleWidth,
+      rowEdited,
     } = this.state;
     const { selected, childSelected, parentSelected } = this.getSelected();
 
@@ -868,6 +879,8 @@ class DocumentList extends Component {
               emptyText={layout.emptyResultText}
               emptyHint={layout.emptyResultHint}
               readonly={true}
+              rowEdited={rowEdited}
+              onRowEdited={this.setTableRowEdited}
               keyProperty="id"
               onDoubleClick={id => !isIncluded && this.redirectToDocument(id)}
               size={data.size}
@@ -911,6 +924,7 @@ class DocumentList extends Component {
                     className="table-flex-wrapper attributes-selector js-not-unselect"
                     entity="documentView"
                     {...{ windowType, viewId }}
+                    onRowEdited={this.setTableRowEdited}
                   >
                     <SelectionAttributes
                       supportAttribute={supportAttribute}

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -156,6 +156,8 @@ class Table extends Component {
       // special case for the picking terminal
       const firstLoad = prevProps.rowData.get(1) ? false : true;
 
+      // this prevents collapsing rows when table cell was edited, for instance
+      // in purchase orders
       if (!rowEdited) {
         this.getIndentData(firstLoad);
       } else {

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -54,7 +54,11 @@ class Table extends Component {
 
     // from <DocumentList>
     onSelectionChanged: PropTypes.func,
+
+    onRowEdited: PropTypes.func,
   };
+
+  _isMounted = false;
 
   constructor(props) {
     super(props);
@@ -79,12 +83,13 @@ class Table extends Component {
       collapsedParentsRows: [],
       pendingInit: true,
       collapsedArrayMap: [],
-      rowEdited: false,
+      rowEdited: props.rowEdited,
     };
   }
 
   componentDidMount() {
     //selecting first table elem while getting indent data
+    this._isMounted = true;
     this.getIndentData(true);
 
     if (this.props.autofocus) {
@@ -106,8 +111,14 @@ class Table extends Component {
       viewId,
       isModal,
       hasIncluded,
+      rowEdited,
+      onRowEdited,
     } = this.props;
-    const { selected, rows, rowEdited } = this.state;
+    const { selected, rows } = this.state;
+
+    if (!this._isMounted) {
+      return;
+    }
 
     if (!_.isEqual(prevState.rows, rows)) {
       if (isModal && !hasIncluded) {
@@ -161,9 +172,7 @@ class Table extends Component {
       if (!rowEdited) {
         this.getIndentData(firstLoad);
       } else {
-        this.setState({
-          rowEdited: false,
-        });
+        onRowEdited && onRowEdited(false);
       }
     }
 
@@ -179,6 +188,8 @@ class Table extends Component {
       windowType,
       isIncluded,
     } = this.props;
+
+    this._isMounted = false;
 
     this.deselectAllProducts();
     if (showIncludedViewOnSelect && !isIncluded) {
@@ -918,7 +929,7 @@ class Table extends Component {
   };
 
   handleItemChange = (rowId, prop, value) => {
-    const { mainTable, keyProperty } = this.props;
+    const { mainTable, keyProperty, onRowEdited } = this.props;
 
     if (mainTable) {
       const { rows } = this.state;
@@ -934,9 +945,7 @@ class Table extends Component {
       });
     }
 
-    this.setState({
-      rowEdited: true,
-    });
+    onRowEdited && onRowEdited(true);
   };
 
   renderTableBody = () => {

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -79,6 +79,7 @@ class Table extends Component {
       collapsedParentsRows: [],
       pendingInit: true,
       collapsedArrayMap: [],
+      rowEdited: false,
     };
   }
 
@@ -106,8 +107,7 @@ class Table extends Component {
       isModal,
       hasIncluded,
     } = this.props;
-
-    const { selected, rows } = this.state;
+    const { selected, rows, rowEdited } = this.state;
 
     if (!_.isEqual(prevState.rows, rows)) {
       if (isModal && !hasIncluded) {
@@ -155,7 +155,14 @@ class Table extends Component {
     if (!is(prevProps.rowData, rowData)) {
       // special case for the picking terminal
       const firstLoad = prevProps.rowData.get(1) ? false : true;
-      this.getIndentData(firstLoad);
+
+      if (!rowEdited) {
+        this.getIndentData(firstLoad);
+      } else {
+        this.setState({
+          rowEdited: false,
+        });
+      }
     }
 
     if (prevProps.viewId !== viewId && defaultSelected.length === 0) {
@@ -924,6 +931,10 @@ class Table extends Component {
         }
       });
     }
+
+    this.setState({
+      rowEdited: true,
+    });
   };
 
   renderTableBody = () => {


### PR DESCRIPTION
We don't want to request updated data, as it causes selection to be dropped and moved to the first line.

Related to #1751 

**This requires #1776 to be merged first**