### PR TITLE
Fix lookup widget in modals with viewId

### DIFF
--- a/src/actions/GenericActions.js
+++ b/src/actions/GenericActions.js
@@ -160,23 +160,37 @@ export function autocompleteRequest({
   tabId,
   viewId,
 }) {
-  return axios.get(
-    config.API_URL +
-      '/' +
-      entity +
-      (docType ? '/' + docType : '') +
-      (viewId ? '/' + viewId : '') +
-      (docId ? '/' + docId : '') +
-      (tabId ? '/' + tabId : '') +
-      (rowId ? '/' + rowId : '') +
-      (subentity ? '/' + subentity : '') +
-      (subentityId ? '/' + subentityId : '') +
-      (attribute ? '/attribute/' : '/field/') +
-      propertyName +
-      '/typeahead' +
-      '?query=' +
-      encodeURIComponent(query)
-  );
+  return axios.get(`${config.API_URL}/${entity}${
+      (docType ? `/${docType}` : '')}${
+      (viewId ? `/${viewId}` : '')}${
+      (docId ? `/${docId}` : '')}${
+      (tabId ? `/${tabId}` : '')}${
+      (rowId ? `/${rowId}` : '')}${
+      (subentity ? `/${subentity}` : '')}${
+      (subentityId ? `/${subentityId}` : '')}${
+      (attribute ? '/attribute/' : '/field/')}${
+      propertyName}/typeahead?query=${encodeURIComponent(query)}
+  `);
+}
+
+export function autocompleteModalRequest({
+  docId,
+  docType,
+  entity,
+  propertyName,
+  query,
+  rowId,
+  tabId,
+  viewId,
+}) {
+  return axios.get(`${config.API_URL}/${entity}${
+      (docType ? `/${docType}` : '')}${
+      (viewId ? `/${viewId}` : '')}${
+      (docId ? `/${docId}` : '')}${
+      (tabId ? `/${tabId}` : '')}${
+      (rowId ? `/${rowId}` : '')}/edit/${
+      propertyName}/typeahead?query=${encodeURIComponent(query)}
+  `);
 }
 
 export function dropdownRequest({

--- a/src/actions/GenericActions.js
+++ b/src/actions/GenericActions.js
@@ -160,16 +160,13 @@ export function autocompleteRequest({
   tabId,
   viewId,
 }) {
-  return axios.get(`${config.API_URL}/${entity}${
-      (docType ? `/${docType}` : '')}${
-      (viewId ? `/${viewId}` : '')}${
-      (docId ? `/${docId}` : '')}${
-      (tabId ? `/${tabId}` : '')}${
-      (rowId ? `/${rowId}` : '')}${
-      (subentity ? `/${subentity}` : '')}${
-      (subentityId ? `/${subentityId}` : '')}${
-      (attribute ? '/attribute/' : '/field/')}${
-      propertyName}/typeahead?query=${encodeURIComponent(query)}
+  return axios.get(`${config.API_URL}/${entity}${docType ? `/${docType}` : ''}${
+    viewId ? `/${viewId}` : ''
+  }${docId ? `/${docId}` : ''}${tabId ? `/${tabId}` : ''}${
+    rowId ? `/${rowId}` : ''
+  }${subentity ? `/${subentity}` : ''}${subentityId ? `/${subentityId}` : ''}${
+    attribute ? '/attribute/' : '/field/'
+  }${propertyName}/typeahead?query=${encodeURIComponent(query)}
   `);
 }
 
@@ -183,13 +180,11 @@ export function autocompleteModalRequest({
   tabId,
   viewId,
 }) {
-  return axios.get(`${config.API_URL}/${entity}${
-      (docType ? `/${docType}` : '')}${
-      (viewId ? `/${viewId}` : '')}${
-      (docId ? `/${docId}` : '')}${
-      (tabId ? `/${tabId}` : '')}${
-      (rowId ? `/${rowId}` : '')}/edit/${
-      propertyName}/typeahead?query=${encodeURIComponent(query)}
+  return axios.get(`${config.API_URL}/${entity}${docType ? `/${docType}` : ''}${
+    viewId ? `/${viewId}` : ''
+  }${docId ? `/${docId}` : ''}${tabId ? `/${tabId}` : ''}${
+    rowId ? `/${rowId}` : ''
+  }/edit/${propertyName}/typeahead?query=${encodeURIComponent(query)}
   `);
 }
 

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -5,7 +5,10 @@ import TetherComponent from 'react-tether';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 
-import { autocompleteRequest } from '../../../actions/GenericActions';
+import {
+  autocompleteRequest,
+  autocompleteModalRequest
+} from '../../../actions/GenericActions';
 import { getViewAttributeTypeahead } from '../../../actions/ViewAttributesActions';
 import { openModal } from '../../../actions/WindowActions';
 import SelectionDropdown from '../SelectionDropdown';
@@ -286,6 +289,17 @@ class RawLookup extends Component {
           mainProperty[0].field,
           this.inputSearch.value
         );
+      } else if (viewId) {
+        typeaheadRequest = autocompleteModalRequest({
+          docId: filterWidget ? viewId : dataId,
+          docType: windowType,
+          entity: 'documentView',
+          propertyName: filterWidget ? parameterName : mainProperty[0].field,
+          query: this.inputSearch.value,
+          viewId,
+          rowId,
+          tabId,
+        });
       } else {
         typeaheadRequest = autocompleteRequest({
           docId: filterWidget ? viewId : dataId,

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 
 import {
   autocompleteRequest,
-  autocompleteModalRequest
+  autocompleteModalRequest,
 } from '../../../actions/GenericActions';
 import { getViewAttributeTypeahead } from '../../../actions/ViewAttributesActions';
 import { openModal } from '../../../actions/WindowActions';


### PR DESCRIPTION
Right now in some modals the lookup widget was hitting incorrect endpoint.

Related to #1765 

TODO:
* [x] ~there's something weird with loading value to the lookup field. Saving gives correct response.~ According to Teo it works as expected.