### PR TITLE
Fix handling view type notifications

### DIFF
--- a/src/api/view.js
+++ b/src/api/view.js
@@ -25,16 +25,12 @@ export function browseViewRequest({
   orderBy,
 }) {
   return get(
-    config.API_URL +
-      '/documentView/' +
-      windowId +
-      '/' +
-      viewId +
-      '?firstRow=' +
-      pageLength * (page - 1) +
-      '&pageLength=' +
-      pageLength +
-      (orderBy ? '&orderBy=' + orderBy : '')
+    `${
+      config.API_URL
+    }/documentView/${windowId}/${viewId}?firstRow=${pageLength *
+      (page - 1)}&pageLength=${pageLength}${
+      orderBy ? `&orderBy=${orderBy}` : ''
+    }`
   );
 }
 

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -134,7 +134,6 @@ class DocumentList extends Component {
       refId,
       windowType,
       dispatch,
-      location,
     } = this.props;
     const { page, sort, viewId, staticFilterCleared } = this.state;
     const included =
@@ -143,6 +142,7 @@ class DocumentList extends Component {
       nextIncludedView &&
       nextIncludedView.windowType &&
       nextIncludedView.viewId;
+    const location = document.location;
 
     this.loadSupportAttributeFlag(nextProps);
 
@@ -179,14 +179,8 @@ class DocumentList extends Component {
           if (included) {
             dispatch(closeListIncludedView(includedView));
           }
-          if (
-            !(
-              location.hash === '#notification' &&
-              document.location.hash !== '#notification'
-            )
-          ) {
-            this.fetchLayoutAndData();
-          }
+
+          this.fetchLayoutAndData();
         }
       );
     }
@@ -980,7 +974,6 @@ const mapStateToProps = (state, props) => ({
         viewId: props.parentDefaultViewId,
       })
     : NO_SELECTION,
-  location: state.routing.locationBeforeTransitions,
 });
 
 export default connect(mapStateToProps, null, null, { withRef: true })(

--- a/src/components/inbox/Inbox.js
+++ b/src/components/inbox/Inbox.js
@@ -2,8 +2,10 @@ import counterpart from 'counterpart';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import onClickOutside from 'react-onclickoutside';
+import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
+import { get } from 'lodash';
 
 import {
   deleteUserNotification,
@@ -24,7 +26,7 @@ class Inbox extends Component {
   };
 
   handleClick = item => {
-    const { dispatch, close } = this.props;
+    const { dispatch, close, location } = this.props;
     if (item.target) {
       switch (item.target.targetType) {
         case 'window':
@@ -32,13 +34,28 @@ class Inbox extends Component {
             push(`/window/${item.target.windowId}/${item.target.documentId}`)
           );
           break;
-        case 'view':
+        case 'view': {
+          // in case we're on the same page, we want to add a hash param
+          // to force refresh of DocumentList component so in order to do that
+          // we check if viewId's are equal
+          let samePageParam = '';
+          const locationViewId = get(location, 'query.viewId').split('-')[0];
+          const targetViewId = item.target.viewId.split('-')[0];
+
+          if (locationViewId === targetViewId) {
+            samePageParam = '#notification';
+          }
+
           dispatch(
             push(
-              `/window/${item.target.windowId}/?viewId=${item.target.viewId}`
+              `/window/${item.target.windowId}/?viewId=${
+                item.target.viewId
+              }${samePageParam}`
             )
           );
+
           break;
+        }
       }
     }
 
@@ -161,6 +178,9 @@ Inbox.defaultProps = {
   onFocus: () => {},
 };
 
-export default connect(state => ({
-  modalVisible: state.windowHandler.modal.visible,
-}))(onClickOutside(Inbox));
+export default withRouter(
+  connect((state, props) => ({
+    modalVisible: state.windowHandler.modal.visible,
+    location: props.router.location,
+  }))(onClickOutside(Inbox))
+);

--- a/src/components/inbox/Inbox.js
+++ b/src/components/inbox/Inbox.js
@@ -176,6 +176,7 @@ Inbox.propTypes = {
   open: PropTypes.bool,
   onFocus: PropTypes.func,
   modalVisible: PropTypes.bool.isRequired,
+  location: PropTypes.object,
 };
 
 Inbox.defaultProps = {

--- a/src/components/inbox/Inbox.js
+++ b/src/components/inbox/Inbox.js
@@ -39,8 +39,12 @@ class Inbox extends Component {
           // to force refresh of DocumentList component so in order to do that
           // we check if viewId's are equal
           let samePageParam = '';
-          const locationViewId = get(location, 'query.viewId').split('-')[0];
-          const targetViewId = item.target.viewId.split('-')[0];
+          const locationViewId = get(location, 'query.viewId')
+            ? get(location, 'query.viewId').split('-')[0]
+            : null;
+          const targetViewId = item.target.viewId
+            ? item.target.viewId.split('-')[0]
+            : null;
 
           if (locationViewId === targetViewId) {
             samePageParam = '#notification';


### PR DESCRIPTION
This fixes loading notifications from the page with the url as the notification url.

@teosarca one thing I've noticed, is that notifications have always the same viewId (in the test case it was `540375-B`) while the viewId on the page was different (`540375-Ee/Dd` or similar). This causes first two requests for data and quickActions to fail with 404, until the page loads and the `viewId` is correct. It's nothing breaking, but still those two requests are visible in the console.

![screen shot 2018-05-17 at 18 25 01](https://user-images.githubusercontent.com/513460/40190599-a0384ec2-59ff-11e8-9312-3f391119868d.png)

![screen shot 2018-05-17 at 18 25 18](https://user-images.githubusercontent.com/513460/40190609-a3e84ee6-59ff-11e8-9655-246e92e872c7.png)

Related to #1789 