### PR TITLE
Typing in dropdown fields

### DIFF
--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -238,6 +238,12 @@ class RawList extends PureComponent {
     onBlur();
   };
 
+  updateTypedText = typedText => {
+    this.setState({
+      typedText,
+    });
+  };
+
   render() {
     const {
       rank,
@@ -259,6 +265,7 @@ class RawList extends PureComponent {
       onFocus,
       clearable,
     } = this.props;
+    const { typedText } = this.state;
 
     let value = '';
     let placeholder = '';
@@ -336,7 +343,7 @@ class RawList extends PureComponent {
                 readOnly
                 tabIndex={-1}
                 placeholder={placeholder}
-                value={value}
+                value={typedText || value}
                 disabled={readonly || disabled}
               />
             </div>
@@ -363,6 +370,7 @@ class RawList extends PureComponent {
               selected={this.state.selected}
               width={this.dropdown.offsetWidth}
               onChange={this.handleTemporarySelection}
+              onSearchChange={this.updateTypedText}
               onSelect={this.handleSelect}
               onCancel={this.handleCancel}
             />

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -137,6 +137,7 @@ class RawList extends PureComponent {
       onOpenDropdown();
     } else {
       onCloseDropdown();
+      this.clearTypedText();
     }
   };
 
@@ -161,6 +162,7 @@ class RawList extends PureComponent {
         () => {
           onCloseDropdown();
           onBlur();
+          this.clearTypedText();
         }
       );
     }
@@ -180,6 +182,7 @@ class RawList extends PureComponent {
         onSelect(selected);
       }
       onCloseDropdown();
+      this.clearTypedText();
     });
   };
 
@@ -200,6 +203,7 @@ class RawList extends PureComponent {
     disableAutofocus && disableAutofocus();
     this.handleBlur();
     onCloseDropdown && onCloseDropdown();
+    this.clearTypedText();
   };
 
   handleKeyDown = e => {
@@ -228,6 +232,8 @@ class RawList extends PureComponent {
       } else {
         this.handleBlur();
       }
+
+      this.clearTypedText();
     }
   };
 
@@ -241,6 +247,12 @@ class RawList extends PureComponent {
   updateTypedText = typedText => {
     this.setState({
       typedText,
+    });
+  };
+
+  clearTypedText = () => {
+    this.setState({
+      typedText: '',
     });
   };
 

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -457,6 +457,7 @@ class RawLookup extends Component {
               onChange={this.handleTemporarySelection}
               onSelect={this.handleSelect}
               onCancel={this.handleBlur}
+              lookupDropdown={true}
             />
           )}
       </TetherComponent>

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -23,6 +23,7 @@ export default class SelectionDropdown extends Component {
     onChange: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
+    onSearchChange: PropTypes.func,
   };
 
   /* Those are instance variables since no rendering needs to be done depending on
@@ -33,6 +34,14 @@ export default class SelectionDropdown extends Component {
   ignoreOption = null;
 
   optionToRef = new Map();
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      searchText: '',
+    };
+  }
 
   componentDidMount() {
     window.addEventListener('keydown', this.handleKeyDown);
@@ -111,11 +120,40 @@ export default class SelectionDropdown extends Component {
     onChange(selectedNew);
   };
 
+  handleBackspace = () => {
+    const { onSearchChange } = this.props;
+    const { searchText } = this.state;
+    const text = searchText.slice(0, -1);
+
+    this.setState({
+      searchText: text,
+    });
+    onSearchChange(text);
+  };
+
   navigateToAlphanumeric = char => {
-    const { selected, options, onChange } = this.props;
-    const items = options.filter(
-      item => item.caption[0].toUpperCase() === char.toUpperCase()
-    );
+    const {
+      selected,
+      options,
+      onChange,
+      lookupDropdown,
+      onSearchChange,
+    } = this.props;
+    const { searchText } = this.state;
+    const text = !lookupDropdown ? searchText + char : char;
+
+    const items = options.filter(item => {
+      const caption = lookupDropdown ? item.caption[0] : item.caption;
+
+      return caption.toUpperCase().indexOf(text.toUpperCase()) > -1;
+    });
+
+    if (!lookupDropdown) {
+      this.setState({
+        searchText: text,
+      });
+      onSearchChange(text);
+    }
 
     const selectedIndex = items.indexOf(selected);
     const itemsSize = items.get ? items.size : items.length;
@@ -140,7 +178,7 @@ export default class SelectionDropdown extends Component {
 
   handleKeyDown = event => {
     const { navigate } = this;
-    const { selected, onCancel, onSelect } = this.props;
+    const { selected, onCancel, onSelect, lookupDropdown } = this.props;
 
     if (event.keyCode > 47 && event.keyCode < 123) {
       this.navigateToAlphanumeric(event.key);
@@ -161,6 +199,12 @@ export default class SelectionDropdown extends Component {
         case 'Enter':
           event.preventDefault();
           onSelect(selected);
+          break;
+        case 'Backspace':
+          if (!lookupDropdown) {
+            event.preventDefault();
+            this.handleBackspace();
+          }
           break;
         default:
           return;

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -180,7 +180,11 @@ export default class SelectionDropdown extends Component {
     const { navigate } = this;
     const { selected, onCancel, onSelect, lookupDropdown } = this.props;
 
-    if (event.keyCode > 47 && event.keyCode < 123) {
+    if (
+      event.keyCode > 47 &&
+      event.keyCode < 111 &&
+      !(event.keyCode >= 91 && event.keyCode < 94)
+    ) {
       this.navigateToAlphanumeric(event.key);
     } else {
       switch (event.key) {


### PR DESCRIPTION
Now when options list is toggled user can see the typed search text. This is only turned on for normal dropdowns, not lookup fields as in the lookups we're already typing. Typed text is cleared when tho dropdown is closed.

Related to #1722 

![screen shot 2018-06-12 at 14 01 10](https://user-images.githubusercontent.com/513460/41289231-609cf1a6-6e49-11e8-81b0-9162d2deddb9.png)
