### PR TITLE
Fix 404 alignment

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1329,6 +1329,7 @@ td.pulse-off input {
     flex-direction: column;
     align-items: center;
     align-self: center;
+    justify-content: center;
 }
 
 .blank-page h1 {


### PR DESCRIPTION
Last fix missed the case for document views, like `window/123/1`.

Related to #1840 