### PR TITLE
Fix pagination and filtering in modals

### DIFF
--- a/src/assets/css/table.css
+++ b/src/assets/css/table.css
@@ -350,7 +350,11 @@
             font-weight: bold;
             color: $brand-font-color;
         }
-    } 
+    }
+
+    &.inactive {
+        cursor: default;
+    }
 }
 
 .page-link {

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -198,6 +198,7 @@ class DocumentList extends Component {
 
     if (nextDefaultViewId !== viewId) {
       dispatch(removeSelectedTableItems({ viewId: viewId, windowType }));
+
       stateChanges.viewId = nextDefaultViewId;
       stateChanges.refreshSelection = true;
     }
@@ -207,9 +208,11 @@ class DocumentList extends Component {
       stateChanges.hasShowIncluded = false;
     }
 
-    this.setState({
-      ...stateChanges,
-    });
+    if (Object.keys(stateChanges).length) {
+      this.setState({
+        ...stateChanges,
+      });
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -458,17 +461,24 @@ class DocumentList extends Component {
   };
 
   filterView = () => {
-    const { windowType } = this.props;
+    const { windowType, isIncluded, dispatch } = this.props;
     const { page, sort, filters, viewId } = this.state;
 
     filterViewRequest(windowType, viewId, filters).then(response => {
+      const viewId = response.data.viewId;
+
+      if (isIncluded) {
+        dispatch(setListIncludedView({ windowType, viewId }));
+      }
+
       this.mounted &&
         this.setState(
           {
             data: response.data,
+            viewId: viewId,
           },
           () => {
-            this.getData(response.data.viewId, page, sort);
+            this.getData(viewId, page, sort);
           }
         );
     });

--- a/src/components/table/TablePagination.js
+++ b/src/components/table/TablePagination.js
@@ -254,17 +254,32 @@ class TablePagination extends PureComponent {
     );
   };
 
-  renderArrow = left => {
+  renderArrow = (left, pages, page) => {
     const { compressed, handleChangePage } = this.props;
+    let disabled = false;
+
+    if (left) {
+      disabled = page === 1 ? true : false;
+    } else {
+      disabled = page === pages ? true : false;
+    }
+
     return (
-      <li className="page-item">
+      <li
+        className={classnames('page-item', {
+          inactive: disabled,
+        })}
+      >
         <a
           className={classnames('page-link', {
             'page-link-compressed': compressed,
+            disabled: disabled,
           })}
           onClick={() => {
-            this.resetGoToPage();
-            handleChangePage(left ? 'down' : 'up');
+            if (!disabled) {
+              this.resetGoToPage();
+              handleChangePage(left ? 'down' : 'up');
+            }
           }}
         >
           <span>{left ? '«' : '»'}</span>
@@ -297,9 +312,7 @@ class TablePagination extends PureComponent {
 
   render() {
     const { size, pageLength, page, compressed } = this.props;
-
     const pages = size ? Math.ceil(size / pageLength) : 0;
-
     let pagination = [];
 
     if (pages < 8) {
@@ -333,9 +346,9 @@ class TablePagination extends PureComponent {
             <div>
               <nav>
                 <ul className="pagination pointer">
-                  {this.renderArrow(true)}
+                  {this.renderArrow(true, pages, page)}
                   {pagination}
-                  {this.renderArrow(false)}
+                  {this.renderArrow(false, pages, page)}
                 </ul>
               </nav>
             </div>


### PR DESCRIPTION
Disabled pagination buttons when needed and fixed saving included view's in the store after filtering, which doesn't disable the filtering now. Checked if it doesn't bring #1394 back and it looks ok.

Related to #1857 & #1858 