### PR TITLE
Use translated texts and fix sales order tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,7 +11,7 @@ dist
 .history
 
 # Dynamic storybook configuration file
-.storybook/foundStories.js
+.storybook
 
 # Coverage report
 .nyc_output
@@ -19,8 +19,10 @@ coverage
 
 package-lock.json
 
+plugins
+docker
+ansible
 test_setup 
 src/__tests__
-cypress
 cypress.json
 yarn-error.log

--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -9,26 +9,24 @@
     "extends": [
         "eslint:recommended",
         "plugin:react/recommended",
-        "prettier"
     ],
     "rules": {
-        "prettier/prettier": ["error", {
-          "singleQuote": true,
-          "trailingComma": "es5"
-        }],
         "react/prop-types": "warn",
         "react/jsx-filename-extension": "off",
         "react/prefer-stateless-function": "off",
         "react/display-name": "warn"
     },
-    "plugins": ["prettier", "react", "jest"],
+    "plugins": ["react", "jest"],
     "globals": {
         "localStorage": true,
         "Promise": true,
         "config": true,
         "PLUGINS": true,
+        "cy": true,
         "context": true,
+        "Cypress": true,
         "before": true,
         "document": true
-    }
+    },
+    "root": true
 }

--- a/cypress/integration/flatrate_conditions_subscription_spec.js
+++ b/cypress/integration/flatrate_conditions_subscription_spec.js
@@ -6,7 +6,7 @@ describe('New subscription flatrate conditions Test', function() {
 
     const flatrateTransitionName = `Cypress Test ${new Date().getTime()}`;
 
-    specify('Create and complete a new flatrate transition record', function() {
+    it('Create and complete a new flatrate transition record', function() {
         describe('Create a new flatrate transition record', function() {
             cy.visit('/window/540120/NEW');
 
@@ -25,7 +25,7 @@ describe('New subscription flatrate conditions Test', function() {
         });
     });
 
-    specify('Create a new flatrate conditions record', function() {
+    it('Create a new flatrate conditions record', function() {
         cy.visit('/window/540113/NEW');
 
         cy.writeIntoStringField('Name', `Cypress Test ${new Date().getTime()}`);

--- a/cypress/integration/sales_order_spec.js
+++ b/cypress/integration/sales_order_spec.js
@@ -1,21 +1,50 @@
+import config from '../config';
+
 describe('New sales order test', function() {
+  const windowId = 143;
+  let caption = '';
+  let nodeId = null;
+  let menuOption = '';
+
   before(function() {
-    // login before each test
     cy.loginByForm();
-    cy.visit('/window/143');
+
+    cy.request('GET', config.API_URL+'/menu/elementPath?type=window&elementId='+windowId+'&inclusive=true')
+      .then((response) => {
+        expect(response.body).to.have.property('captionBreadcrumb');
+        expect(response.body).to.have.property('nodeId');
+        caption = response.body.captionBreadcrumb;
+        nodeId = response.body.nodeId;
+
+        cy.request('GET', config.API_URL+'/menu/node/'+nodeId+'/breadcrumbMenu')
+          .then((response) => {
+            const resp = response.body;
+            expect(resp.length).to.be.gt(0);
+
+            for (let i=0; i<resp.length; i+= 1) {
+              if (resp[i].nodeId === '1000040-new') {
+                menuOption = resp[i].caption;
+
+                break;
+              }
+            }
+        });
+    });
+
+    cy.visit('/window/'+windowId);
   });
 
   context('Create a new sales order', function() {
     before(function() {
       cy.get('.header-breadcrumb')
-        .contains('.header-item', 'Sales', { timeout: 10000 })
+        .contains('.header-item', caption, { timeout: 10000 })
         .click();
 
       cy.get('.header-breadcrumb')
         .find('.menu-overlay')
         .should('exist')
         .find('.menu-overlay-link')
-        .contains('New Sales Order')
+        .contains(menuOption)
         .click();
 
       cy.get('.header-breadcrumb-sitename').should('contain', '<');
@@ -26,12 +55,12 @@ describe('New sales order test', function() {
         .first()
         .find('input')
         .clear()
-        .type('G0001');
+        .type('G0002');
 
       cy.get('.input-dropdown-list').should('exist');
-      cy.contains('.input-dropdown-list-option', 'Test Kunde 1')
-        .click();
-      cy.get('.input-dropdown-list .input-dropdown-list-header')
+      cy.contains('.input-dropdown-list-option', 'Test Lieferant 1').click();
+      cy
+        .get('.input-dropdown-list .input-dropdown-list-header')
         .should('not.exist');
 
       cy.get('.header-breadcrumb-sitename').should('not.contain', '<');

--- a/cypress/integration/sales_order_spec.js
+++ b/cypress/integration/sales_order_spec.js
@@ -22,7 +22,7 @@ describe('New sales order test', function() {
             expect(resp.length).to.be.gt(0);
 
             for (let i=0; i<resp.length; i+= 1) {
-              if (resp[i].nodeId === '1000040-new') {
+              if (resp[i].nodeId.includes('-new')) {
                 menuOption = resp[i].caption;
 
                 break;

--- a/cypress/integration/sales_order_spec.js
+++ b/cypress/integration/sales_order_spec.js
@@ -107,44 +107,40 @@ describe('New sales order test', function() {
 
     it('Change document status', function() {
       let completeActionCaption = '';
+      const draftedCaption = Cypress.reduxStore.getState()
+        .windowHandler.master.data.DocStatus.value.caption;
+      const docId = Cypress.reduxStore.getState().windowHandler.master.docId;
 
-        const docId = Cypress.reduxStore.getState().windowHandler.master.docId;
+      cy.request('GET', config.API_URL+'/window/'+windowId+'/'+docId+'/field/DocAction/dropdown')
+        .then((response) => {
+          const resp = response.body;
 
-        cy.request('GET', config.API_URL+'/window/'+windowId+'/'+docId+'/field/DocAction/dropdown')
-          .then((response) => {
-            const resp = response.body;
+          expect(resp).to.have.property('values');
+          expect(resp.values.length).to.be.gt(0);
 
-            expect(resp).to.have.property('values');
-            expect(resp.values.length).to.be.gt(0);
+          for (let i=0; i<resp.values.length; i+= 1) {
+            if (resp.values[i].key === 'CO') {
+              completeActionCaption = resp.values[i].caption;
 
-            for (let i=0; i<resp.values.length; i+= 1) {
-              if (resp.values[i].key === 'CO') {
-                completeActionCaption = resp.values[i].caption;
-
-                break;
-              }
+              break;
             }
+          }
 
+          cy.get('.form-field-DocAction')
+            .find('.meta-dropdown-toggle')
+            .click();
 
-            cy.get('.form-field-DocAction')
-              .find('.meta-dropdown-toggle')
-              .click();
+          cy.get('.form-field-DocAction')
+            .find('.dropdown-status-toggler')
+            .should('have.class', 'dropdown-status-open');
 
-            cy.get('.form-field-DocAction')
-              .find('.dropdown-status-toggler')
-              .should('have.class', 'dropdown-status-open');
+          cy.get('.form-field-DocAction .dropdown-status-list')
+            .find('.dropdown-status-item')
+            .contains(completeActionCaption)
+            .click();
 
-            cy.get('.form-field-DocAction .dropdown-status-list')
-              .find('.dropdown-status-item')
-
-              .contains(completeActionCaption)
-              .click();
-
-            cy.get('.indicator-pending', { timeout: 10000 }).should('not.exist');
-
-            const completedCaption = Cypress.reduxStore.getState()
-              .windowHandler.master.data.DocStatus.value.caption;
-              cy.get('.meta-dropdown-toggle .tag-success').contains(completedCaption);
+          cy.get('.indicator-pending', { timeout: 10000 }).should('not.exist');
+          cy.get('.meta-dropdown-toggle .tag-success').should('not.contain', draftedCaption);
         });
     });
   });

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -25,6 +25,10 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   return false
 });
 
+Cypress.on('emit:counterpartTranslations', messages => {
+  Cypress.messages = messages;
+});
+
 /**
  * Emulates Tab key navigation.
  */

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -15,11 +15,12 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import nextTabbable from './nextTabbable';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on('uncaught:exception', () =>{ //(err, runnable) => {
   // returning false here prevents Cypress from
   // failing the test
   return false

--- a/src/components/Translation.js
+++ b/src/components/Translation.js
@@ -13,6 +13,10 @@ class Translation extends Component {
 
   _getMessages = () => {
     getMessages().then(response => {
+      if (window.Cypress) {
+        window.Cypress.emit('emit:counterpartTranslations', response.data);
+      }
+
       counterpart.registerTranslations('lang', response.data);
       counterpart.setLocale('lang');
       counterpart.setMissingEntryGenerator(function(key) {


### PR DESCRIPTION
Now instead of hardcoded texts (which would break when other languages were used) we can use translations and captions from data responses.