### PR TITLE
Fix closing attributes widget

### DIFF
--- a/cypress/integration/business_partner_widgets_spec.js
+++ b/cypress/integration/business_partner_widgets_spec.js
@@ -1,23 +1,18 @@
+import config from '../config';
+
 describe('Business partner window widgets test', function() {
   before(function() {
     // login before each test
     cy.loginByForm();
+    cy.visit('/window/123/2156447');
+    cy
+      .get('.header-breadcrumb-sitename')
+      .should('contain', 'Cypress Test Partner #1');
   });
 
   context('Tabs', function() {
-    beforeEach(function() {
-      cy.visit('/window/123/2156447');
-      cy
-        .get('.header-breadcrumb-sitename')
-        .should('contain', 'Cypress Test Partner #1');
-    });
-
     context('Vendor', function() {
       it('Check if list widget works properly', function() {
-        cy
-          .get('.header-breadcrumb-sitename')
-          .should('contain', 'Cypress Test Partner #1');
-
         cy
           .get('.nav-item[title="Vendor"]')
           .click()
@@ -48,6 +43,74 @@ describe('Business partner window widgets test', function() {
           .find('.input-dropdown-list-option')
           .contains('Pickup');
       });
+    });
+  });
+
+  context('Location', function() {
+
+    it('Edit existing address', function() {
+      cy.get('.nav-item[title="Location"]').click()
+
+      cy.get('.tab-content table tbody tr').last().find('td').first().should('exist')
+      .trigger('contextmenu')
+      cy.get('.context-menu').find('.context-menu-item')
+        .contains('Advanced edit')
+        .click();
+
+      cy.get('.panel-modal').should('exist')
+        .get('.form-field-C_Location_ID')
+        .find('button')
+        .click();
+
+      cy.get('.panel-modal .attributes-dropdown').should('exist')
+        .get('.form-field-C_Country_ID')
+        .find('.input-icon-lg')
+        .click();
+
+      cy.get('.panel-modal .form-field-C_Country_ID')
+        .find('input')
+        .type('Germany')
+
+        cy.get('.input-dropdown-list')
+          .should('exist')
+          .find('.input-dropdown-list-option')
+          .contains('Germany')
+          .click();
+
+        cy.get('.panel-modal-header').click().find('button').click();
+        cy.get('.input-dropdown-list').should('not.exist');
+    });
+
+    after(function() {
+      cy
+        .get('.nav-item[title="Location"]')
+        .click()
+
+      cy.get('.tab-content table tr').last().trigger('contextmenu')
+      cy.get('.context-menu').find('.context-menu-item')
+        .contains('Advanced edit')
+        .click();
+
+      cy.get('.panel-modal')
+        .get('.form-field-C_Location_ID')
+        .find('button')
+        .click();
+
+      cy.get('.panel-modal .attributes-dropdown')
+        .get('.form-field-C_Country_ID')
+        .find('.input-icon-lg')
+        .click();
+
+      cy.get('.panel-modal .form-field-C_Country_ID')
+        .find('input')
+        .type('Poland')
+
+        cy.get('.input-dropdown-list')
+          .find('.input-dropdown-list-option')
+          .contains('Poland')
+          .click();
+
+        cy.get('.panel-modal-header').click().find('button').click();    
     });
   });
 });

--- a/cypress/integration/sales_order_widgets_spec.js
+++ b/cypress/integration/sales_order_widgets_spec.js
@@ -48,6 +48,8 @@ describe('Sales order window widgets test', function() {
 
       // this should hide the attributes panel
       cy.get('.row-selected .ProductAttributes').click();
+
+      //this command doesn't really work right now, but hopefuly will work soon :)
       cy.get('body').type('{esc}');
       cy.get('.input-dropdown-list').should('not.exist');
 
@@ -70,7 +72,6 @@ describe('Sales order window widgets test', function() {
         .contains('No')
         .click()
 
-      // this should hide the attributes panel
       cy.get('.row-selected .Integer').click();
     });
   });

--- a/cypress/integration/sales_order_widgets_spec.js
+++ b/cypress/integration/sales_order_widgets_spec.js
@@ -1,13 +1,12 @@
 describe('Sales order window widgets test', function() {
   before(function() {
-    // login before each test
     cy.loginByForm();
     cy.visit('/window/143/1000489');
     cy.get('.header-breadcrumb-sitename').should('contain', '0359');
   });
 
   // This is tested in sales_order_spec.js
-  context('Toggle widgets', function() {
+  // context('Toggle widgets', function() {
     // beforeEach(function() {
     //   cy.visit('/window/143/1000489');
     //   cy.get('.header-breadcrumb-sitename').should('contain', '0359');
@@ -27,7 +26,7 @@ describe('Sales order window widgets test', function() {
     //     .get('.input-dropdown-list .input-dropdown-list-header')
     //     .should('not.exist');
     // });
-  });
+  // });
 
   context('Edit product in list', function() {
     it('Change product attributes', function() {
@@ -44,12 +43,35 @@ describe('Sales order window widgets test', function() {
 
       cy.get('.input-dropdown-list').should('exist')
         .find('.input-dropdown-list-option')
+        .contains('Yes')
+        .click()
+
+      // this should hide the attributes panel
+      cy.get('.row-selected .ProductAttributes').click();
+      cy.get('body').type('{esc}');
+      cy.get('.input-dropdown-list').should('not.exist');
+
+      cy.get('.form-field-M_AttributeSetInstance_ID').contains('Yes');
+    });
+
+    // cleanup
+    after(function() {
+      cy.get('.ProductAttributes').find('.productattributes-cell').last().click();
+
+      cy.get('.form-field-M_AttributeSetInstance_ID')
+        .find('button').click();
+
+      cy.get('.form-field-IsRepackNumberRequired')
+        .find('.input-dropdown-container')
+        .click();
+
+      cy.get('.input-dropdown-list').should('exist')
+        .find('.input-dropdown-list-option')
         .contains('No')
         .click()
 
       // this should hide the attributes panel
       cy.get('.row-selected .Integer').click();
-      cy.get('.input-dropdown-list').should('not.exist')
     });
   });
 });

--- a/cypress/integration/sales_order_widgets_spec.js
+++ b/cypress/integration/sales_order_widgets_spec.js
@@ -2,27 +2,54 @@ describe('Sales order window widgets test', function() {
   before(function() {
     // login before each test
     cy.loginByForm();
+    cy.visit('/window/143/1000489');
+    cy.get('.header-breadcrumb-sitename').should('contain', '0359');
   });
 
+  // This is tested in sales_order_spec.js
   context('Toggle widgets', function() {
-    beforeEach(function() {
-      cy.visit('/window/143/1000489');
-      cy.get('.header-breadcrumb-sitename').should('contain', '0359');
-    });
+    // beforeEach(function() {
+    //   cy.visit('/window/143/1000489');
+    //   cy.get('.header-breadcrumb-sitename').should('contain', '0359');
+    // });
 
-    it('Select lookup option', function() {
-      cy
-        .get('.input-dropdown-container .raw-lookup-wrapper')
-        .first()
-        .find('input')
-        .clear()
-        .type('test');
+    // it('Select lookup option', function() {
+    //   cy
+    //     .get('.input-dropdown-container .raw-lookup-wrapper')
+    //     .first()
+    //     .find('input')
+    //     .clear()
+    //     .type('test');
 
-      cy.get('.input-dropdown-list').should('exist');
-      cy.contains('.input-dropdown-list-option', '1000004_kaystest').click();
-      cy
-        .get('.input-dropdown-list .input-dropdown-list-header')
-        .should('not.exist');
+    //   cy.get('.input-dropdown-list').should('exist');
+    //   cy.contains('.input-dropdown-list-option', '1000004_kaystest').click();
+    //   cy
+    //     .get('.input-dropdown-list .input-dropdown-list-header')
+    //     .should('not.exist');
+    // });
+  });
+
+  context('Edit product in list', function() {
+    it('Change product attributes', function() {
+      cy.get('.ProductAttributes').find('.productattributes-cell').last().dblclick();
+
+      cy.get('.form-field-M_AttributeSetInstance_ID').should('exist')
+        .find('button').click();
+
+      cy.get('.attributes-dropdown').should('exist');
+
+      cy.get('.form-field-IsRepackNumberRequired')
+        .find('.input-dropdown-container')
+        .click();
+
+      cy.get('.input-dropdown-list').should('exist')
+        .find('.input-dropdown-list-option')
+        .contains('No')
+        .click()
+
+      // this should hide the attributes panel
+      cy.get('.row-selected .Integer').click();
+      cy.get('.input-dropdown-list').should('not.exist')
     });
   });
 });

--- a/src/components/widget/Attributes/AttributesDropdown.js
+++ b/src/components/widget/Attributes/AttributesDropdown.js
@@ -85,6 +85,7 @@ class AttributesDropdown extends Component {
             enableOnClickOutside={enableOnClickOutside}
             tabIndex={tabIndex}
             isModal={isModal}
+            attributeWidget={true}
           />
         );
       });

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -64,7 +64,7 @@ class RawWidget extends Component {
     }
 
     // don't disable onclickoutside for the attributes widget
-    if (entity !== 'pattribute') {
+    if (entity !== 'pattribute' && entity !== 'address') {
       disableOnClickOutside && disableOnClickOutside();
     }
     handleFocus && handleFocus();

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -56,7 +56,7 @@ class RawWidget extends Component {
    * DOM element outside of it's parent's tree.
    */
   focus = () => {
-    const { handleFocus, disableOnClickOutside, entity } = this.props;
+    const { handleFocus, disableOnClickOutside, attributeWidget } = this.props;
     const { rawWidget } = this;
 
     if (rawWidget && rawWidget.focus) {
@@ -64,7 +64,7 @@ class RawWidget extends Component {
     }
 
     // don't disable onclickoutside for the attributes widget
-    if (entity !== 'pattribute' && entity !== 'address') {
+    if (!attributeWidget) {
       disableOnClickOutside && disableOnClickOutside();
     }
     handleFocus && handleFocus();


### PR DESCRIPTION
After selecting option in lookup that's positioned in attributes widget app will react to clicking outside and close the widget. Tests included.


Related to #1895 .