### PR TITLE
Handle quickactions shortcuts with included views

### DIFF
--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -864,6 +864,7 @@ class DocumentList extends Component {
                   shouldNotUpdate={inBackground && !hasIncluded}
                   inBackground={disablePaginationShortcuts}
                   inModal={inModal}
+                  stopShortcutPropagation={isIncluded && selected}
                   childView={
                     hasIncluded
                       ? {

--- a/src/components/app/QuickActions.js
+++ b/src/components/app/QuickActions.js
@@ -248,6 +248,7 @@ class QuickActions extends Component {
             handleClick={() =>
               shouldNotUpdate ? null : this.handleClick(actions[0])
             }
+            stopPropagation={this.props.stopShortcutPropagation}
             onClick={() => this.toggleDropdown(!isDropdownOpen)}
           />
         </div>

--- a/src/components/keyshortcuts/QuickActionsContextShortcuts.js
+++ b/src/components/keyshortcuts/QuickActionsContextShortcuts.js
@@ -8,11 +8,21 @@ export default class QuickActionsContextShortcuts extends Component {
       event.preventDefault();
 
       this.props.handleClick();
+
+      if (this.props.stopPropagation) {
+        return true;
+      }
+      return false;
     },
     QUICK_ACTION_TOGGLE: event => {
       event.preventDefault();
 
       this.props.onClick();
+
+      if (this.props.stopPropagation) {
+        return true;
+      }
+      return false;
     },
   };
 


### PR DESCRIPTION
When there's included view and a valid selection, quickactions will first react to the included view's shortcut.

Related to #1901 