### PR TITLE
Non mandatory blue fields in grid view

### DIFF
--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -233,7 +233,6 @@ class TableItem extends PureComponent {
                     ...cellWidget,
                     widgetType: item.widgetType,
                     displayed: true,
-                    mandatory: true,
                     readonly: false,
                   };
                 }


### PR DESCRIPTION
For some reason all editable widgets in cells were changed to be mandatory. 

Related to #1887 