### PR TITLE
Fixes for filters modal

### DIFF
--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -911,7 +911,9 @@ td.pulse-off input {
 
 .filter-widget {
     padding: 8px 13px 12px 13px;
-    min-width: 480px;
+    min-width: 200px;
+    width: 200px;
+    max-width: 480px;
     max-height: 80vh;
     overflow-y: auto;
     overflow-x: hidden;

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -928,6 +928,12 @@ td.pulse-off input {
     color: white;
 }
 
+.filter-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .filter-clear {
     font-size: 11px;
     color: $brand-icon-color;

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -864,7 +864,7 @@ class DocumentList extends Component {
                   shouldNotUpdate={inBackground && !hasIncluded}
                   inBackground={disablePaginationShortcuts}
                   inModal={inModal}
-                  stopShortcutPropagation={isIncluded && selected}
+                  stopShortcutPropagation={isIncluded && !!selected}
                   childView={
                     hasIncluded
                       ? {

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -199,7 +199,10 @@ class Filters extends Component {
     const { notValidFields, widgetShown, filter } = this.state;
 
     return (
-      <div className="filter-wrapper js-not-unselect">
+      <div
+        className="filter-wrapper js-not-unselect"
+        ref={c => (this.filtersWrapper = c)}
+      >
         <span className="filter-caption">
           {`${counterpart.translate('window.filters.caption')}: `}
         </span>
@@ -216,6 +219,7 @@ class Filters extends Component {
               clearFilters={this.clearFilters}
               active={filter}
               dropdownToggled={this.dropdownToggled}
+              filtersWrapper={this.filtersWrapper}
             />
           )}
           {!!notFrequentFilters.length && (
@@ -230,6 +234,7 @@ class Filters extends Component {
               clearFilters={this.clearFilters}
               active={filter}
               dropdownToggled={this.dropdownToggled}
+              filtersWrapper={this.filtersWrapper}
             />
           )}
         </div>

--- a/src/components/filters/FiltersFrequent.js
+++ b/src/components/filters/FiltersFrequent.js
@@ -180,6 +180,7 @@ FiltersFrequent.propTypes = {
   allowOutsideClick: PropTypes.bool.isRequired,
   modalVisible: PropTypes.bool.isRequired,
   active: PropTypes.array,
+  filtersWrapper: PropTypes.any,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersFrequent.js
+++ b/src/components/filters/FiltersFrequent.js
@@ -139,6 +139,7 @@ class FiltersFrequent extends PureComponent {
                     viewId={viewId}
                     outsideClick={this.outsideClick}
                     openedFilter={true}
+                    filtersWrapper={this.props.filtersWrapper}
                   />
                 )}
               </div>

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import TetherComponent from 'react-tether';
+import ReactDOM from 'react-dom';
 
 import keymap from '../../shortcuts/keymap';
 import OverlayField from '../app/OverlayField';
@@ -22,6 +23,7 @@ class FiltersItem extends Component {
     this.state = {
       filter: props.data,
       isTooltipShow: false,
+      maxWidth: null,
     };
   }
 
@@ -40,6 +42,26 @@ class FiltersItem extends Component {
   componentDidMount() {
     if (this.widgetsContainer) {
       this.widgetsContainer.addEventListener('scroll', this.handleScroll);
+    }
+
+    if (this.props.filtersWrapper) {
+      /* eslint-disable react/no-find-dom-node */
+      const widgetElement = ReactDOM.findDOMNode(this.widgetsContainer);
+      const buttonElement = widgetElement.closest('.filter-wrapper');
+      const wrapperElement = ReactDOM.findDOMNode(this.props.filtersWrapper);
+      /* eslint-enablereact/no-find-dom-node */
+      const wrapperRight = wrapperElement.getBoundingClientRect().right;
+
+      const documentElement = wrapperElement.closest('.document-lists-wrapper');
+      const documentRight = documentElement.getBoundingClientRect().right;
+
+      if (parent) {
+        const offset = documentRight - wrapperRight + buttonElement.offsetWidth;
+
+        this.setState({
+          maxWidth: offset,
+        });
+      }
     }
   }
 
@@ -179,7 +201,12 @@ class FiltersItem extends Component {
       captionValue,
       openedFilter,
     } = this.props;
-    const { filter, isTooltipShow } = this.state;
+    const { filter, isTooltipShow, maxWidth } = this.state;
+    const style = {};
+
+    if (maxWidth) {
+      style.width = maxWidth;
+    }
 
     return (
       <div>
@@ -198,6 +225,7 @@ class FiltersItem extends Component {
         ) : (
           <div
             className="filter-menu filter-widget"
+            style={style}
             ref={c => (this.widgetsContainer = c)}
           >
             <div className="filter-controls">

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -335,6 +335,7 @@ class FiltersItem extends Component {
 
 FiltersItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  filtersWrapper: PropTypes.any,
 };
 
 export default connect()(FiltersItem);

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -200,9 +200,11 @@ class FiltersItem extends Component {
             className="filter-menu filter-widget"
             ref={c => (this.widgetsContainer = c)}
           >
-            <div>
-              {counterpart.translate('window.activeFilter.caption')}:
-              <span className="filter-active">{data.caption}</span>
+            <div className="filter-controls">
+              <div>
+                {counterpart.translate('window.activeFilter.caption')}:
+                <span className="filter-active">{data.caption}</span>
+              </div>
               {isActive && (
                 <span
                   className="filter-clear"

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -24,6 +24,7 @@ class FiltersItem extends Component {
       filter: props.data,
       isTooltipShow: false,
       maxWidth: null,
+      maxHeight: null,
     };
   }
 
@@ -48,18 +49,26 @@ class FiltersItem extends Component {
       /* eslint-disable react/no-find-dom-node */
       const widgetElement = ReactDOM.findDOMNode(this.widgetsContainer);
       const buttonElement = widgetElement.closest('.filter-wrapper');
+      const buttonClientRect = buttonElement.getBoundingClientRect();
       const wrapperElement = ReactDOM.findDOMNode(this.props.filtersWrapper);
       /* eslint-enablereact/no-find-dom-node */
       const wrapperRight = wrapperElement.getBoundingClientRect().right;
-
       const documentElement = wrapperElement.closest('.document-lists-wrapper');
-      const documentRight = documentElement.getBoundingClientRect().right;
+      const documentClientRect = documentElement.getBoundingClientRect();
 
       if (parent) {
-        const offset = documentRight - wrapperRight + buttonElement.offsetWidth;
+        const offset = ~~(
+          documentClientRect.right -
+          wrapperRight +
+          buttonClientRect.width
+        );
+        const height =
+          ~~(documentClientRect.top + documentClientRect.height) -
+          ~~(buttonClientRect.top + buttonClientRect.height);
 
         this.setState({
           maxWidth: offset,
+          maxHeight: height,
         });
       }
     }
@@ -201,11 +210,12 @@ class FiltersItem extends Component {
       captionValue,
       openedFilter,
     } = this.props;
-    const { filter, isTooltipShow, maxWidth } = this.state;
+    const { filter, isTooltipShow, maxWidth, maxHeight } = this.state;
     const style = {};
 
     if (maxWidth) {
       style.width = maxWidth;
+      style.maxHeight = maxHeight;
     }
 
     return (

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -121,6 +121,7 @@ class FiltersNotFrequent extends Component {
                 onHide={() => handleShow(false)}
                 viewId={viewId}
                 outsideClick={this.outsideClick}
+                openedFilter={true}
               />
             )}
           </div>

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -135,6 +135,7 @@ class FiltersNotFrequent extends Component {
 FiltersNotFrequent.propTypes = {
   allowOutsideClick: PropTypes.bool.isRequired,
   modalVisible: PropTypes.bool.isRequired,
+  filtersWrapper: PropTypes.any,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -122,6 +122,7 @@ class FiltersNotFrequent extends Component {
                 viewId={viewId}
                 outsideClick={this.outsideClick}
                 openedFilter={true}
+                filtersWrapper={this.props.filtersWrapper}
               />
             )}
           </div>


### PR DESCRIPTION
Various fixes for the filters modal widget:
- fix keyboard shortcuts for applying filters in modals
- fix layout when `Clear` button appears
- fix width and height of the widget to not exceed the height of the window/modal

Related to #1890 #1911