### PR TITLE
Lookup/List widget changes

### DIFF
--- a/src/components/widget/List/List.js
+++ b/src/components/widget/List/List.js
@@ -154,8 +154,7 @@ class ListWidget extends Component {
       if (values.length === 0 && lastProperty) {
         disableAutofocus();
       } else if (
-        !ignoreFocus &&
-        this.state.autoFocus &&
+        (ignoreFocus || this.state.autoFocus) &&
         values &&
         values.length > 1
       ) {

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -174,7 +174,10 @@ class Lookup extends Component {
   //   );
   // };
 
-  dropdownListToggle = (value, field) => {
+  // mouse param is to tell us if we should enable listening to keys
+  // in Table or not. If user selected option with mouse, we still
+  // wait for more keyboard action (until the field is blurred with keyboard)
+  dropdownListToggle = (value, field, mouse) => {
     const { onFocus, onBlur } = this.props;
 
     this._changeWidgetProperty(field, 'dropdownOpen', value, () => {
@@ -182,16 +185,18 @@ class Lookup extends Component {
         isDropdownListOpen: value,
       });
 
-      if (value && onFocus) {
-        onFocus();
-      } else if (!value && onBlur) {
-        onBlur();
+      if (mouse) {
+        if (value && onFocus) {
+          onFocus();
+        } else if (!value && onBlur) {
+          onBlur();
+        }
       }
     });
   };
 
   resetLocalClearing = () => {
-    // TODO: Rewrite per widget
+    // TODO: Rewrite per widget if needed
     this.setState({
       localClearing: false,
     });
@@ -426,8 +431,8 @@ class Lookup extends Component {
                   onBlur={() => this.handleListBlur(item.field)}
                   onFocus={() => this.handleListFocus(item.field)}
                   isOpen={lookupWidget.dropdownOpen}
-                  onDropdownListToggle={val => {
-                    this.dropdownListToggle(val, item.field);
+                  onDropdownListToggle={(val, mouse) => {
+                    this.dropdownListToggle(val, item.field, mouse);
                   }}
                   forcedWidth={width}
                   parentElement={forceFullWidth && this.dropdown}

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -136,7 +136,7 @@ class RawLookup extends Component {
     });
   };
 
-  handleSelect = select => {
+  handleSelect = (select, mouse) => {
     const {
       onChange,
       handleInputEmptyStatus,
@@ -196,7 +196,7 @@ class RawLookup extends Component {
       this.inputSearch.focus();
     }, 0);
 
-    this.handleBlur();
+    this.handleBlur(mouse);
   };
 
   handleAddNew = () => {
@@ -227,13 +227,13 @@ class RawLookup extends Component {
     );
   };
 
-  handleBlur = () => {
+  handleBlur = mouse => {
     this.setState(
       {
         isFocused: false,
       },
       () => {
-        this.props.onDropdownListToggle(false);
+        this.props.onDropdownListToggle(false, mouse);
       }
     );
   };

--- a/src/components/widget/SelectionDropdown.js
+++ b/src/components/widget/SelectionDropdown.js
@@ -196,7 +196,7 @@ export default class SelectionDropdown extends Component {
   };
 
   handleMouseDown = option => {
-    this.props.onSelect(option);
+    this.props.onSelect(option, true);
   };
 
   renderHeader = children => {


### PR DESCRIPTION
- fix case when user uses keyboard only to change value of a lookup field multiple times (without loosing focus). Related to #1785 
- bring back auto toggle of list fields, when lookup group returns multiple results for field. Related to #1923 

Even after all my cleanups this widget is still super complicated and hard to maintain. Need to think of a way to unit-test this.