### PR TITLE
Fix patching in process modals

### DIFF
--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -586,14 +586,13 @@ export function patch(
 
     try {
       const response = await patchRequest(options);
-
       const data =
         response.data instanceof Array ? response.data : [response.data];
       await dispatch(
         mapDataToState(data, isModal, rowId, id, windowType, isAdvanced)
       );
 
-      if (!data[0].validStatus.valid) {
+      if (data[0].validStatus && !data[0].validStatus.valid) {
         await dispatch(indicatorState('error'));
         await dispatch({ type: PATCH_FAILURE, symbol });
         const errorMessage = data[0].validStatus.reason;

--- a/src/actions/WindowActions.js
+++ b/src/actions/WindowActions.js
@@ -716,7 +716,9 @@ function updateRow(row, scope) {
 
 function mapDataToState(data, isModal, rowId, id, windowType, isAdvanced) {
   return dispatch => {
-    data.map((item, index) => {
+    const dataArray = typeof data.splice === 'function' ? data : [data];
+
+    dataArray.map((item, index) => {
       const parsedItem = item.fieldsByName
         ? {
             ...item,


### PR DESCRIPTION
Related to #1934 

It seems some data is missing in the response, and instead of an array of fields we're getting just an object. Not sure if this is intentional or not. @teosarca ?

![screen shot 2018-08-27 at 11 53 06](https://user-images.githubusercontent.com/513460/44653984-87c6d480-a9f0-11e8-8900-931686d87648.png)

Also after fixing the errors and with the checkboxes selected I still can't generate invoices successfully because of some error.

![screen shot 2018-08-27 at 11 54 19](https://user-images.githubusercontent.com/513460/44654011-9614f080-a9f0-11e8-9339-bc9d09d6ef1e.png)

