### PR TITLE
Improve HOME/END handling for inputs

### DIFF
--- a/src/components/keyshortcuts/GlobalContextShortcuts.js
+++ b/src/components/keyshortcuts/GlobalContextShortcuts.js
@@ -146,7 +146,11 @@ export default class GlobalContextShortcuts extends Component {
 
       const activeElement = document.activeElement;
 
-      if (activeElement && activeElement.nodeName === 'INPUT') {
+      if (
+        activeElement &&
+        activeElement.nodeName === 'INPUT' &&
+        activeElement.type === 'text'
+      ) {
         this.setCaretPosition(activeElement, activeElement.value.length);
 
         return true;


### PR DESCRIPTION
Only text inputs support moving caret, so this PR limits our previous solution to text inputs to avoid errors in the console. #1188 