### PR TITLE
Fix filter captions and showing filters with default value

### DIFF
--- a/src/api/view.js
+++ b/src/api/view.js
@@ -3,6 +3,8 @@ import Moment from 'moment';
 import { getQueryString } from '../utils';
 import { DATE_FORMAT } from '../constants/Constants';
 
+import _ from 'lodash';
+
 export function getViewLayout(windowId, viewType, viewProfileId = null) {
   return get(
     `${config.API_URL}/documentView/${windowId}/layout?viewType=${viewType}${
@@ -80,6 +82,9 @@ export function filterViewRequest(windowId, viewId, filters) {
         }
       });
   });
+
+  console.log('filterViewRequest: ', _.cloneDeep(filters));
+
   return post(`${config.API_URL}/documentView/${windowId}/${viewId}/filter`, {
     filters: filters,
   });

--- a/src/api/view.js
+++ b/src/api/view.js
@@ -3,8 +3,6 @@ import Moment from 'moment';
 import { getQueryString } from '../utils';
 import { DATE_FORMAT } from '../constants/Constants';
 
-import _ from 'lodash';
-
 export function getViewLayout(windowId, viewType, viewProfileId = null) {
   return get(
     `${config.API_URL}/documentView/${windowId}/layout?viewType=${viewType}${
@@ -82,8 +80,6 @@ export function filterViewRequest(windowId, viewId, filters) {
         }
       });
   });
-
-  console.log('filterViewRequest: ', _.cloneDeep(filters));
 
   return post(`${config.API_URL}/documentView/${windowId}/${viewId}/filter`, {
     filters: filters,

--- a/src/api/view.js
+++ b/src/api/view.js
@@ -61,11 +61,11 @@ export function createViewRequest({
     }
   }
 
-  return post(config.API_URL + '/documentView/' + windowId, {
+  return post(`${config.API_URL}/documentView/${windowId}`, {
     documentType: windowId,
-    viewType: viewType,
-    referencing: referencing,
-    filters: filters,
+    viewType,
+    referencing,
+    filters,
   });
 }
 

--- a/src/assets/css/filtersitem.css
+++ b/src/assets/css/filtersitem.css
@@ -7,6 +7,8 @@
     .btn-filter {
         padding: 0.425rem .6rem;
         max-width: 300px;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -6,8 +6,6 @@ import { push } from 'react-router-redux';
 import { Map, List, Set } from 'immutable';
 import currentDevice from 'current-device';
 
-import _ from 'lodash';
-
 import {
   getViewLayout,
   browseViewRequest,
@@ -153,7 +151,6 @@ class DocumentList extends Component {
           location.hash === '#notification')) ||
       nextRefId !== refId
     ) {
-      // console.error('RESET EVERYWTHING')
       this.setState(
         {
           data: null,
@@ -410,14 +407,11 @@ class DocumentList extends Component {
 
   filterView = () => {
     const { windowType, isIncluded, dispatch } = this.props;
-    const { page, sort, _filtersActive, filtersActive, viewId } = this.state;
-
-    console.log('DocumentList filterView: ', _.cloneDeep(filtersActive), _.cloneDeep(_filtersActive));
+    const { page, sort, filtersActive, viewId } = this.state;
 
     filterViewRequest(
       windowType,
       viewId,
-      // _filtersActive ? _filtersActive.toIndexedSeq().toArray() : filtersActive.toIndexedSeq().toArray()
       filtersActive.toIndexedSeq().toArray()
     ).then(response => {
       const viewId = response.data.viewId;
@@ -512,8 +506,6 @@ class DocumentList extends Component {
           newState.filtersActive = filtersToMap(response.data.filters);
         }
 
-        console.log('response already ? ', {...newState}, response.data);
-
         this.setState({ ...newState }, () => {
           if (forceSelection && response.data && result && result.size > 0) {
             const selection = [result.get(0).id];
@@ -576,11 +568,8 @@ class DocumentList extends Component {
   };
 
   handleFilterChange = activeFilters => {
-    console.log('HANDLEFILTERCHANGE: ', _.cloneDeep(activeFilters));
-
     this.setState(
       {
-        // filtersActive: _.cloneDeep(activeFilters),
         filtersActive: activeFilters,
         page: 1,
       },
@@ -596,9 +585,9 @@ class DocumentList extends Component {
 
     if (!filterParams) {
       filterParams = Set([parameterName]);
+    } else {
+      filterParams = filterParams.add(parameterName);
     }
-
-    console.warn('DL resetInitialFilters: ', filterId, parameterName);
 
     initialValuesNulled = initialValuesNulled.set(filterId, filterParams);
 

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -499,7 +499,7 @@ class DocumentList extends Component {
               result,
             },
             pageColumnInfosByFieldName: pageColumnInfosByFieldName,
-            filters: filtersToMap(response.data.filters),
+            filtersActive: filtersToMap(response.data.filters),
           },
           () => {
             if (forceSelection && response.data && result && result.size > 0) {
@@ -694,7 +694,7 @@ class DocumentList extends Component {
       viewId,
       clickOutsideLock,
       page,
-      activeFilters,
+      filtersActive,
       isShowIncluded,
       hasShowIncluded,
       refreshSelection,
@@ -782,7 +782,8 @@ class DocumentList extends Component {
 
                 {layout.filters && (
                   <Filters
-                    {...{ windowType, viewId, activeFilters }}
+                    {...{ windowType, viewId }}
+                    activeFilters={filtersActive}
                     filterData={filtersToMap(layout.filters)}
                     updateDocList={this.handleFilterChange}
                   />

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -564,8 +564,6 @@ class DocumentList extends Component {
   };
 
   handleFilterChange = activeFilters => {
-    console.log('handleFilterChange: ', [...activeFilters]);
-
     this.setState(
       {
         filtersActive: activeFilters,

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -492,29 +492,31 @@ class DocumentList extends Component {
       );
 
       if (this.mounted) {
-        this.setState(
-          {
-            data: {
-              ...response.data,
-              result,
-            },
-            pageColumnInfosByFieldName: pageColumnInfosByFieldName,
-            filtersActive: filtersToMap(response.data.filters),
+        const newState = {
+          data: {
+            ...response.data,
+            result,
           },
-          () => {
-            if (forceSelection && response.data && result && result.size > 0) {
-              const selection = [result.get(0).id];
+          pageColumnInfosByFieldName: pageColumnInfosByFieldName,
+        };
 
-              dispatch(
-                selectTableItems({
-                  windowType,
-                  viewId,
-                  ids: selection,
-                })
-              );
-            }
+        if (response.data.filters) {
+          newState.filtersActive = filtersToMap(response.data.filters);
+        }
+
+        this.setState({ ...newState }, () => {
+          if (forceSelection && response.data && result && result.size > 0) {
+            const selection = [result.get(0).id];
+
+            dispatch(
+              selectTableItems({
+                windowType,
+                viewId,
+                ids: selection,
+              })
+            );
           }
-        );
+        });
       }
 
       dispatch(indicatorState('saved'));

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -564,9 +564,11 @@ class DocumentList extends Component {
   };
 
   handleFilterChange = activeFilters => {
+    console.log('handleFilterChange: ', [...activeFilters]);
+
     this.setState(
       {
-        activeFilters,
+        filtersActive: activeFilters,
         page: 1,
       },
       () => {
@@ -782,8 +784,7 @@ class DocumentList extends Component {
 
                 {layout.filters && (
                   <Filters
-                    {...{ windowType, viewId }}
-                    activeFilters={filtersActive}
+                    {...{ windowType, viewId, filtersActive }}
                     filterData={filtersToMap(layout.filters)}
                     updateDocList={this.handleFilterChange}
                   />

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -583,13 +583,17 @@ class DocumentList extends Component {
     let { initialValuesNulled } = this.state;
     let filterParams = initialValuesNulled.get(filterId);
 
-    if (!filterParams) {
+    if (!filterParams && parameterName) {
       filterParams = Set([parameterName]);
-    } else {
+    } else if (filterParams && parameterName) {
       filterParams = filterParams.add(parameterName);
     }
 
-    initialValuesNulled = initialValuesNulled.set(filterId, filterParams);
+    if (!parameterName) {
+      initialValuesNulled = initialValuesNulled.delete(filterId);
+    } else {
+      initialValuesNulled = initialValuesNulled.set(filterId, filterParams);
+    }
 
     this.setState({
       initialValuesNulled,

--- a/src/components/app/DocumentList.js
+++ b/src/components/app/DocumentList.js
@@ -804,7 +804,12 @@ class DocumentList extends Component {
 
                 {layout.filters && (
                   <Filters
-                    {...{ windowType, viewId, filtersActive, initialValuesNulled }}
+                    {...{
+                      windowType,
+                      viewId,
+                      filtersActive,
+                      initialValuesNulled,
+                    }}
                     filterData={filtersToMap(layout.filters)}
                     updateDocList={this.handleFilterChange}
                     resetInitialValues={this.resetInitialFilters}

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -5,7 +5,7 @@ import { Map } from 'immutable';
 
 import _ from 'lodash';
 
-import { filtersToMap } from '../../utils/documentListHelper';
+// import { filtersToMap } from '../../utils/documentListHelper';
 import TableCell from '../table/TableCell';
 import FiltersFrequent from './FiltersFrequent';
 import FiltersNotFrequent from './FiltersNotFrequent';
@@ -28,7 +28,7 @@ class Filters extends Component {
   }
 
   // PARSING FILTERS ---------------------------------------------------------
-  parseActiveFilters = () => {
+  parseActiveFilters = (cb) => {
     let { filtersActive, filterData, initialValuesNulled } = this.props;
     let activeFilters = _.cloneDeep(filtersActive);
     const activeFiltersCaptions = {};
@@ -95,7 +95,7 @@ class Filters extends Component {
           // }
 
           const singleActiveFilter = activeFilters.get(filterId);
-          paramsArray = singleActiveFilter.parameters;
+          paramsArray = singleActiveFilter ? singleActiveFilter.parameters : [];
           // let length = paramsArray.length,
           //   extendedParams = [],
           //   seen = new Set();
@@ -157,7 +157,7 @@ class Filters extends Component {
     });
 
     if (activeFilters.size) {
-      const removeDefault = {};
+      // const removeDefault = {};
 
       // console.info('activeFilterssize: ', activeFilters)
 
@@ -166,13 +166,14 @@ class Filters extends Component {
 
         filter.parameters.forEach(filterParameter => {
           const { value, parameterName, defaultValue } = filterParameter;
-          const valueExists = filterParameter.hasOwnProperty('value');
+          // const valueExists = filterParameter.hasOwnProperty('value');
+
           // we don't want to show captions, nor show filter button as active
           // for default values
-          if (valueExists && !defaultValue) {
-            // console.log('TA ?: ', value, parameterName)
-            removeDefault[filterId] = true;
-          }
+          // if (valueExists && !defaultValue) {
+          //   // console.log('TA ?: ', value, parameterName)
+          //   removeDefault[filterId] = true;
+          // }
 
           if (!defaultValue) {
             const parentFilter = filterData.get(filterId);
@@ -228,24 +229,24 @@ class Filters extends Component {
         }
       });
 
-      if (Object.keys(removeDefault).length) {
-        console.log('remove ?: ', removeDefault, activeFilters)
-        for (let key of Object.keys(removeDefault)) {
-          activeFilters = activeFilters.setIn([key, 'defaultVal'], false);
-        }
-      }
+      // if (Object.keys(removeDefault).length) {
+      //   console.log('remove ?: ', removeDefault, activeFilters)
+      //   for (let key of Object.keys(removeDefault)) {
+      //     activeFilters = activeFilters.setIn([key, 'defaultVal'], false);
+      //   }
+      // }
 
       console.info('ACTIVE: ',  _.cloneDeep(activeFilters), _.cloneDeep(filtersActive));
 
       this.setState({
         activeFilter: activeFilters.toIndexedSeq().toArray(),
         activeFiltersCaptions,
-      });
+      }, () => cb && cb());
     } else {
       this.setState({
         activeFilter: null,
         activeFiltersCaptions: null,
-      });
+      }, () => cb && cb());
     }
   };
 
@@ -362,29 +363,43 @@ class Filters extends Component {
 
   setFilterActive = filterToAdd => {
     const { updateDocList } = this.props;
-    const { activeFilter } = this.state;
-    let newFilter;
+    // const { activeFilter } = this.state;
 
-    if (activeFilter) {
-      newFilter = activeFilter.filter(
-        item => item.filterId !== filterToAdd.filterId
-      );
-      newFilter.push(filterToAdd);
-    } else {
-      newFilter = [filterToAdd];
-    }
+    let { filtersActive } = this.props;
+    let activeFilters = Map(filtersActive);
+    // let newFilter;
+
+    // console.log('ACTIVE FILTERS: ', {...filterToAdd}, _.cloneDeep(activeFilters));
+
+    activeFilters = activeFilters.filter((item, id) => id !== filterToAdd.filterId)
+    activeFilters = activeFilters.set(filterToAdd.filterId, filterToAdd);
+
+
+    // if (activeFilter) {
+    //   newFilter = _.cloneDeep(activeFilter);
+    //   newFilter = newFilter.filter(
+    //     item => item.filterId !== filterToAdd.filterId
+    //   );
+    //   newFilter.push(filterToAdd);
+    // } else {
+    //   newFilter = [filterToAdd];
+    // }
     // console.log('FILTER TO ADD: ', _.cloneDeep(newFilter));
     // console.log('NEWFILTER: ', [...newFilter])
-    const filtersMap = filtersToMap(newFilter);
+    // const filtersMap = filtersToMap(newFilter);
     // console.log('AAAND FILTER MAP ? ', filtersMap, _.cloneDeep(filtersMap));
+
     // this.setState(
     //   {
     //     activeFilter: newFilter,
     //   },
     //   () => {
-        updateDocList(filtersMap);
+    //     this.parseActiveFilters(updateDocList(filtersMap));
+        // updateDocList(filtersMap);
+
       // }
     // );
+    updateDocList(activeFilters);
   };
 
   /*
@@ -399,24 +414,47 @@ class Filters extends Component {
 
   clearFilters = filterToClear => {
     const { updateDocList } = this.props;
-    const { activeFilter } = this.state;
+    // const { activeFilter } = this.state;
 
-    if (activeFilter) {
-      let newFilter = activeFilter.filter(
-        item => item.filterId !== filterToClear.filterId
-      );
+    let { filtersActive } = this.props;
+    let activeFilters = Map(filtersActive);
+    // let newFilter;
 
-      const filtersMap = filtersToMap(newFilter);
+    // console.log('ACTIVE FILTERS: ', {...filterToAdd}, _.cloneDeep(activeFilters));
 
-      this.setState(
-        {
-          activeFilter: newFilter,
-        },
-        () => {
-          updateDocList(filtersMap);
-        }
-      );
+    // activeFilters = activeFilters.filter((item, id) => id !== filterToAdd.filterId)
+    // activeFilters = activeFilters.set(filterToAdd.filterId, filterToAdd);
+
+    if (filtersActive.size) {
+      activeFilters = activeFilters.filter((item, id) => id !== filterToClear.filterId)
+      // activeFilters = activeFilters.set(filterToClear.filterId, filterToClear);
+
+      // this.setState(
+      //   {
+      //     activeFilter: newFilter,
+      //   },
+        // () => {
+          updateDocList(activeFilters);
+        // }
+      // );
     }
+
+    // if (activeFilter) {
+    //   let newFilter = activeFilter.filter(
+    //     item => item.filterId !== filterToClear.filterId
+    //   );
+
+    //   const filtersMap = filtersToMap(newFilter);
+
+    //   this.setState(
+    //     {
+    //       activeFilter: newFilter,
+    //     },
+    //     () => {
+    //       updateDocList(filtersMap);
+    //     }
+    //   );
+    // }
   };
 
   dropdownToggled = () => {

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -402,6 +402,8 @@ class Filters extends Component {
 
 Filters.propTypes = {
   windowType: PropTypes.string.isRequired,
+  // this should be an immutable Map
+  filtersActive: PropTypes.any,
 };
 
 export default Filters;

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -67,6 +67,7 @@ class Filters extends Component {
               extendedParams.push({
                 parameterName,
                 value: defaultValue,
+                defaultVal: true,
               });
               seen.add(parameterName);
             }
@@ -82,6 +83,7 @@ class Filters extends Component {
               extendedParams.push({
                 parameterName,
                 value: defaultValue,
+                defaultVal: true,
               });
             }
 
@@ -98,51 +100,55 @@ class Filters extends Component {
       filtersActive.forEach((filter, filterId) => {
         const captionsArray = ['', ''];
 
-        filter.parameters.forEach(({ value, parameterName }) => {
-          const parentFilter = filterData.get(filterId);
-          const filterParameter = parentFilter.parameters.find(
-            param => param.parameterName === parameterName
-          );
-          let captionName = filterParameter.caption;
-          let itemCaption = filterParameter.caption;
+        filter.parameters.forEach(({ value, parameterName, defaultVal }) => {
+          // we don't want to show captions, nor show filter button as active
+          // for default values
+          if (!defaultVal) {
+            const parentFilter = filterData.get(filterId);
+            const filterParameter = parentFilter.parameters.find(
+              param => param.parameterName === parameterName
+            );
+            let captionName = filterParameter.caption;
+            let itemCaption = filterParameter.caption;
 
-          switch (filterParameter.widgetType) {
-            case 'Text':
-              captionName = value;
+            switch (filterParameter.widgetType) {
+              case 'Text':
+                captionName = value;
 
-              if (!value) {
-                captionName = '';
-                itemCaption = '';
-              }
-              break;
-            case 'List':
-              captionName = value && value.caption;
-              break;
-            case 'Labels':
-              captionName = value.values.reduce((caption, item) => {
-                return `${caption}, ${item.caption}`;
-              }, '');
-              break;
-            case 'YesNo':
-            case 'Switch':
-            default:
-              if (!value) {
-                captionName = '';
-                itemCaption = '';
-              }
-              break;
-          }
+                if (!value) {
+                  captionName = '';
+                  itemCaption = '';
+                }
+                break;
+              case 'List':
+                captionName = value && value.caption;
+                break;
+              case 'Labels':
+                captionName = value.values.reduce((caption, item) => {
+                  return `${caption}, ${item.caption}`;
+                }, '');
+                break;
+              case 'YesNo':
+              case 'Switch':
+              default:
+                if (!value) {
+                  captionName = '';
+                  itemCaption = '';
+                }
+                break;
+            }
 
-          if (captionName) {
-            captionsArray[0] = captionsArray[0]
-              ? `${captionsArray[0]}, ${captionName}`
-              : captionName;
-          }
+            if (captionName) {
+              captionsArray[0] = captionsArray[0]
+                ? `${captionsArray[0]}, ${captionName}`
+                : captionName;
+            }
 
-          if (itemCaption) {
-            captionsArray[1] = captionsArray[1]
-              ? `${captionsArray[1]}, ${itemCaption}`
-              : itemCaption;
+            if (itemCaption) {
+              captionsArray[1] = captionsArray[1]
+                ? `${captionsArray[1]}, ${itemCaption}`
+                : itemCaption;
+            }
           }
         });
 

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -106,8 +106,11 @@ class Filters extends Component {
         filter.parameters.forEach(({ value, parameterName, defaultVal }) => {
           // we don't want to show captions, nor show filter button as active
           // for default values
-          if (!defaultVal) {
+          if (value) {
             removeDefault[filterId] = true;
+          }
+
+          if (!defaultVal) {
             const parentFilter = filterData.get(filterId);
             const filterParameter = parentFilter.parameters.find(
               param => param.parameterName === parameterName
@@ -163,7 +166,7 @@ class Filters extends Component {
 
       if (Object.keys(removeDefault).length) {
         for (let key of Object.keys(removeDefault)) {
-          filtersActive = filtersActive.set(key, { defaultVal: false });
+          filtersActive = filtersActive.setIn([key, 'defaultVal'], false);
         }
       }
 

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -35,7 +35,7 @@ class Filters extends Component {
         outerParameters: for (let parameter of filter.parameters) {
           const { defaultValue, parameterName } = parameter;
 
-          if (defaultValue) {
+          if (filtersActive && defaultValue) {
             const isActive = filtersActive.has(filterId);
 
             if (isActive) {
@@ -110,9 +110,13 @@ class Filters extends Component {
             case 'Text':
               captionName = value;
 
+              if (!value) {
+                captionName = '';
+                itemCaption = '';
+              }
               break;
             case 'List':
-              captionName = value.caption;
+              captionName = value && value.caption;
               break;
             case 'Labels':
               captionName = value.values.reduce((caption, item) => {
@@ -122,19 +126,29 @@ class Filters extends Component {
             case 'YesNo':
             case 'Switch':
             default:
+              if (!value) {
+                captionName = '';
+                itemCaption = '';
+              }
               break;
           }
 
-          captionsArray[0] = captionsArray[0]
-            ? `${captionsArray[0]}, ${captionName}`
-            : captionName;
+          if (captionName) {
+            captionsArray[0] = captionsArray[0]
+              ? `${captionsArray[0]}, ${captionName}`
+              : captionName;
+          }
 
-          captionsArray[1] = captionsArray[1]
-            ? `${captionsArray[1]}, ${itemCaption}`
-            : itemCaption;
+          if (itemCaption) {
+            captionsArray[1] = captionsArray[1]
+              ? `${captionsArray[1]}, ${itemCaption}`
+              : itemCaption;
+          }
         });
 
-        activeFiltersCaptions[filterId] = captionsArray;
+        if (captionsArray.join('').length) {
+          activeFiltersCaptions[filterId] = captionsArray;
+        }
       });
 
       this.setState({
@@ -267,12 +281,14 @@ class Filters extends Component {
         item => item.filterId !== filterToClear.filterId
       );
 
+      const filtersMap = filtersToMap(newFilter);
+
       this.setState(
         {
           activeFilter: newFilter,
         },
         () => {
-          updateDocList(newFilter);
+          updateDocList(filtersMap);
         }
       );
     }

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -10,7 +10,7 @@ import FiltersNotFrequent from './FiltersNotFrequent';
 class Filters extends Component {
   state = {
     activeFilter: null,
-    activeFiltersCaptions: {},
+    activeFiltersCaptions: null,
     notValidFields: null,
     widgetShown: false,
   };
@@ -89,6 +89,7 @@ class Filters extends Component {
 
             filtersActive = filtersActive.set(filterId, {
               filterId,
+              defaultVal: true,
               parameters: extendedParams,
             });
           }
@@ -97,6 +98,8 @@ class Filters extends Component {
     });
 
     if (filtersActive.size) {
+      const removeDefault = {};
+
       filtersActive.forEach((filter, filterId) => {
         const captionsArray = ['', ''];
 
@@ -104,6 +107,7 @@ class Filters extends Component {
           // we don't want to show captions, nor show filter button as active
           // for default values
           if (!defaultVal) {
+            removeDefault[filterId] = true;
             const parentFilter = filterData.get(filterId);
             const filterParameter = parentFilter.parameters.find(
               param => param.parameterName === parameterName
@@ -157,14 +161,20 @@ class Filters extends Component {
         }
       });
 
+      if (Object.keys(removeDefault).length) {
+        for (let key of Object.keys(removeDefault)) {
+          filtersActive = filtersActive.set(key, { defaultVal: false });
+        }
+      }
+
       this.setState({
         activeFilter: filtersActive.toIndexedSeq().toArray(),
         activeFiltersCaptions,
       });
     } else {
       this.setState({
-        activeFilter: [],
-        activeFiltersCaptions: [],
+        activeFilter: null,
+        activeFiltersCaptions: null,
       });
     }
   };
@@ -202,7 +212,9 @@ class Filters extends Component {
     const { activeFilter } = this.state;
 
     if (activeFilter) {
-      const active = activeFilter.find(item => item.filterId === filterId);
+      const active = activeFilter.find(
+        item => item.filterId === filterId && !item.defaultVal
+      );
 
       return typeof active !== 'undefined';
     }

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -155,6 +155,11 @@ class Filters extends Component {
         activeFilter: filtersActive.toIndexedSeq().toArray(),
         activeFiltersCaptions,
       });
+    } else {
+      this.setState({
+        activeFilter: [],
+        activeFiltersCaptions: [],
+      });
     }
   };
 

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -44,9 +44,7 @@ class Filters extends Component {
       filtersActive.forEach((filter, filterId) => {
         const captionsArray = ['', ''];
 
-        console.log('active params ?: ', filter, filterId)
-
-        filter.parameters.forEach(({ value, parameterName}) => {
+        filter.parameters.forEach(({ value, parameterName }) => {
           const parentFilter = filterData.get(filterId);
           const filterParameter = parentFilter.parameters.find(
             param => param.parameterName === parameterName
@@ -54,29 +52,21 @@ class Filters extends Component {
           let captionName = filterParameter.caption;
           let itemCaption = filterParameter.caption;
 
-          console.log('HE ?: ', value, parameterName, filterParameter)
-
           switch (filterParameter.widgetType) {
             case 'Text':
               captionName = value;
-              // itemCaption = filterParameter.caption;
               break;
             case 'List':
               captionName = value.caption;
-              // itemCaption = filterParameter.caption;
               break;
             case 'Labels':
-            // values array, { key:, caption: }
               captionName = value.values.reduce((caption, item) => {
                 return `${caption}, ${item.caption}`;
               }, '');
-              // itemCaption = filterParameter.caption;
               break;
             case 'YesNo':
             case 'Switch':
             default:
-              // captionName = filterParameter.caption;
-              // itemCaption = filterParameter.caption;
               break;
           }
           captionsArray[0] = captionsArray[0]
@@ -89,8 +79,6 @@ class Filters extends Component {
 
         activeFiltersCaptions[filterId] = captionsArray;
       });
-
-      console.log('filtersactive: ', filtersActive.toIndexedSeq().toArray(), activeFiltersCaptions);
 
       this.setState({
         activeFilter: filtersActive.toIndexedSeq().toArray(),
@@ -156,8 +144,6 @@ class Filters extends Component {
   applyFilters = ({ isActive, captionValue, ...filter }, cb) => {
     const valid = this.isFilterValid(filter);
 
-    console.log('APPLY: ', filter);
-
     this.setState(
       {
         notValidFields: !valid,
@@ -193,34 +179,17 @@ class Filters extends Component {
       newFilter = [filterToAdd];
     }
 
-    console.log('new filter: ', { ...newFilter });
-
     const filtersMap = filtersToMap(newFilter);
 
     this.setState(
       {
-        activeFilter: filtersMap,
-        // activeFilter: filtersToMap(newFilter),
+        activeFilter: newFilter,
       },
       () => {
-        // updateDocList(newFilter);
         updateDocList(filtersMap);
       }
     );
   };
-
-    // const activeFilters = data.filter(filter => filter.isActive);
-    // const activeFilter = activeFilters.length === 1 && activeFilters[0];
-
-    // let caption = activeFilter ? activeFilter.caption : 'Filter';
-    // if (activeFilter.captionValue && activeFilter.captionValue.length) {
-    //   caption = activeFilter.captionValue;
-    // }
-
-    // // buttonCaption meta, foo, Active,
-    //   // for textFields value
-    //   // for switch 
-    // // panelCaption Name, Search Key, Active
 
   /*
      *  Method to lock backdrop, to do not close on click onClickOutside
@@ -295,7 +264,12 @@ class Filters extends Component {
     const { frequentFilters, notFrequentFilters } = this.sortFilters(
       filterData
     );
-    const { notValidFields, widgetShown, activeFilter } = this.state;
+    const {
+      notValidFields,
+      widgetShown,
+      activeFilter,
+      activeFiltersCaptions,
+    } = this.state;
 
     return (
       <div
@@ -308,12 +282,15 @@ class Filters extends Component {
         <div className="filter-wrapper">
           {!!frequentFilters.length && (
             <FiltersFrequent
-              windowType={windowType}
+              {...{
+                activeFiltersCaptions,
+                windowType,
+                notValidFields,
+                viewId,
+                widgetShown,
+              }}
               data={frequentFilters}
-              notValidFields={notValidFields}
-              viewId={viewId}
               handleShow={this.handleShow}
-              widgetShown={widgetShown}
               applyFilters={this.applyFilters}
               clearFilters={this.clearFilters}
               active={activeFilter}
@@ -323,12 +300,15 @@ class Filters extends Component {
           )}
           {!!notFrequentFilters.length && (
             <FiltersNotFrequent
-              windowType={windowType}
+              {...{
+                activeFiltersCaptions,
+                windowType,
+                notValidFields,
+                viewId,
+                widgetShown,
+              }}
               data={notFrequentFilters}
-              notValidFields={notValidFields}
-              viewId={viewId}
               handleShow={this.handleShow}
-              widgetShown={widgetShown}
               applyFilters={this.applyFilters}
               clearFilters={this.clearFilters}
               active={activeFilter}

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -424,9 +424,11 @@ class Filters extends Component {
 Filters.propTypes = {
   windowType: PropTypes.string.isRequired,
   resetInitialValues: PropTypes.func.isRequired,
+  viewId: PropTypes.string,
 
   // this should be an immutable Map
   filtersActive: PropTypes.any,
+  filterData: PropTypes.any,
   initialValuesNulled: PropTypes.any,
 };
 

--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -31,13 +31,10 @@ class Filters extends Component {
     // find any filters with default values first and extend
     // activeFilters with them
     filterData.forEach((filter, filterId) => {
-      // console.log('filter: ', filterData)
       filter.parameters &&
         filter.parameters.forEach(({ defaultValue, parameterName }) => {
           if (defaultValue) {
             const isActive = filtersActive.has(filterId);
-
-            console.log('parseActive: ', defaultValue, parameterName, filterId, isActive)
 
             if (!isActive) {
               filtersActive = filtersActive.set(filterId, {
@@ -52,8 +49,17 @@ class Filters extends Component {
               extendedParams = [],
               seen = new Set();
 
+            if (!paramsArray.length) {
+              extendedParams.push({
+                parameterName,
+                value: defaultValue,
+              });
+              seen.add(parameterName)
+            }
+
             outer: for (let index = 0; index < length; index += 1) {
               let name = paramsArray[index].parameterName;
+
               if (seen.has(name) || !paramsArray[index].defaultValue) {
                 continue outer;
               }

--- a/src/components/filters/FiltersFrequent.js
+++ b/src/components/filters/FiltersFrequent.js
@@ -187,6 +187,7 @@ FiltersFrequent.propTypes = {
   modalVisible: PropTypes.bool.isRequired,
   active: PropTypes.array,
   filtersWrapper: PropTypes.any,
+  activeFiltersCaptions: PropTypes.array,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersFrequent.js
+++ b/src/components/filters/FiltersFrequent.js
@@ -187,7 +187,7 @@ FiltersFrequent.propTypes = {
   modalVisible: PropTypes.bool.isRequired,
   active: PropTypes.array,
   filtersWrapper: PropTypes.any,
-  activeFiltersCaptions: PropTypes.array,
+  activeFiltersCaptions: PropTypes.object,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersFrequent.js
+++ b/src/components/filters/FiltersFrequent.js
@@ -58,6 +58,7 @@ class FiltersFrequent extends PureComponent {
       clearFilters,
       active,
       modalVisible,
+      activeFiltersCaptions,
     } = this.props;
     const { openFilterId } = this.state;
 
@@ -75,6 +76,11 @@ class FiltersFrequent extends PureComponent {
             DATE_FIELD_TYPES.includes(filterType) &&
             !TIME_FIELD_TYPES.includes(filterType);
 
+          const isActive =
+            item.isActive && activeFiltersCaptions[item.filterId]
+              ? activeFiltersCaptions[item.filterId]
+              : null;
+
           if (item.inlineRenderMode === 'button') {
             return (
               <div className="filter-wrapper" key={index}>
@@ -90,7 +96,7 @@ class FiltersFrequent extends PureComponent {
                   onClick={() => this.toggleFilter(item.filterId)}
                   className={cx(classes, {
                     ['btn-select']: openFilterId === index,
-                    ['btn-active']: item.isActive,
+                    ['btn-active']: isActive,
                     ['btn-distance']: !dateStepper,
                   })}
                   tabIndex={modalVisible ? -1 : 0}

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -28,7 +28,7 @@ class FiltersItem extends Component {
 
     this.state = {
       filter: { ...props.data },
-      activeFilter: active ? { ...activeFilter } : null,
+      activeFilter: activeFilter ? { ...activeFilter } : null,
       isTooltipShow: false,
       maxWidth: null,
       maxHeight: null,
@@ -100,7 +100,7 @@ class FiltersItem extends Component {
           this.mergeData(item.parameterName, item.defaultValue, '', true);
         } else {
           this.mergeData(item.parameterName, '');
-        }    
+        }
       });
 
       if (

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -96,7 +96,11 @@ class FiltersItem extends Component {
 
     if (filter.parameters) {
       filter.parameters.map(item => {
-        this.mergeData(item.parameterName, '');
+        if (item.defaultValue != null) {
+          this.mergeData(item.parameterName, item.defaultValue, '', true);
+        } else {
+          this.mergeData(item.parameterName, '');
+        }    
       });
 
       if (

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -101,8 +101,8 @@ class FiltersItem extends Component {
           item.parameterName,
           '',
           '',
-          item.defaultValue ? true: false,
-          item.defaultValue,
+          item.defaultValue ? true : false,
+          item.defaultValue
         );
       });
 
@@ -117,7 +117,7 @@ class FiltersItem extends Component {
             item.value != null ? item.value : '',
             item.valueTo != null ? item.valueTo : '',
             true,
-            item.value !== undefined ? item.value : item.defaultValue,
+            item.value !== undefined ? item.value : item.defaultValue
           );
         });
       }

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -239,9 +239,15 @@ class FiltersItem extends Component {
   };
 
   handleClear = () => {
-    const { clearFilters, closeFilterMenu, returnBackToDropdown } = this.props;
+    const {
+      clearFilters,
+      closeFilterMenu,
+      returnBackToDropdown,
+      resetInitialValues,
+    } = this.props;
     const { filter } = this.state;
 
+    resetInitialValues(filter.filterId);
     clearFilters(filter);
     closeFilterMenu();
     returnBackToDropdown && returnBackToDropdown();

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -118,7 +118,7 @@ class FiltersItem extends Component {
     }
   };
 
-  setValue = (property, value, id, valueTo='', filterId, defaultValue) => {
+  setValue = (property, value, id, valueTo ='', filterId, defaultValue) => {
     const { resetInitialValues } = this.props;
 
     if (defaultValue != null) {
@@ -410,6 +410,7 @@ class FiltersItem extends Component {
 
 FiltersItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  applyFilters: PropTypes.func.isRequired,
   resetInitialValues: PropTypes.func.isRequired,
   filtersWrapper: PropTypes.any,
   panelCaption: PropTypes.string,

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -418,6 +418,7 @@ FiltersItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
   applyFilters: PropTypes.func.isRequired,
   resetInitialValues: PropTypes.func.isRequired,
+  clearFilters: PropTypes.func,
   filtersWrapper: PropTypes.any,
   panelCaption: PropTypes.string,
   active: PropTypes.array,

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -247,6 +247,7 @@ class FiltersItem extends Component {
       outsideClick,
       captionValue,
       openedFilter,
+      panelCaption,
     } = this.props;
     const { filter, isTooltipShow, maxWidth, maxHeight } = this.state;
     const style = {};
@@ -279,7 +280,7 @@ class FiltersItem extends Component {
             <div className="filter-controls">
               <div>
                 {counterpart.translate('window.activeFilter.caption')}:
-                <span className="filter-active">{data.caption}</span>
+                <span className="filter-active">{panelCaption}</span>
               </div>
               {isActive && (
                 <span

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -97,7 +97,13 @@ class FiltersItem extends Component {
 
     if (filter.parameters) {
       filter.parameters.map(item => {
-        this.mergeData(item.parameterName, '');
+        this.mergeData(
+          item.parameterName,
+          '',
+          '',
+          item.defaultValue ? true: false,
+          item.defaultValue,
+        );
       });
 
       if (
@@ -111,7 +117,7 @@ class FiltersItem extends Component {
             item.value != null ? item.value : '',
             item.valueTo != null ? item.valueTo : '',
             true,
-            item.defaultValue
+            item.value !== undefined ? item.value : item.defaultValue,
           );
         });
       }
@@ -170,9 +176,13 @@ class FiltersItem extends Component {
           return {
             ...param,
             value: this.parseDateToReadable(param.widgetType, activeValue),
+            defaultValue: null,
           };
         } else {
-          return param;
+          return {
+            ...param,
+            defaultValue: null,
+          };
         }
       });
 
@@ -180,6 +190,7 @@ class FiltersItem extends Component {
         updatedParameters.push({
           parameterName: property,
           value: activeValue,
+          defaultValue: null,
         });
       }
 

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -387,6 +387,8 @@ class FiltersItem extends Component {
 FiltersItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
   filtersWrapper: PropTypes.any,
+  panelCaption: PropTypes.string,
+  active: PropTypes.array,
 };
 
 export default connect()(FiltersItem);

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -118,7 +118,7 @@ class FiltersItem extends Component {
     }
   };
 
-  setValue = (property, value, id, valueTo ='', filterId, defaultValue) => {
+  setValue = (property, value, id, valueTo = '', filterId, defaultValue) => {
     const { resetInitialValues } = this.props;
 
     if (defaultValue != null) {

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -20,15 +20,15 @@ class FiltersItem extends Component {
   constructor(props) {
     super(props);
 
-    const { active } = props;
+    const { active, data } = props;
     let activeFilter = null;
     if (active) {
-      activeFilter = active.find(item => item.filterId === props.data.filterId);
+      activeFilter = active.find(item => item.filterId === data.filterId);
     }
 
     this.state = {
       filter: { ...props.data },
-      activeFilter: { ...activeFilter },
+      activeFilter: active ? { ...activeFilter } : null,
       isTooltipShow: false,
       maxWidth: null,
       maxHeight: null,
@@ -140,10 +140,18 @@ class FiltersItem extends Component {
   };
 
   mergeData = (property, value, valueTo, updateActive) => {
-    let { activeFilter } = this.state;
+    let { activeFilter, filter } = this.state;
 
     if (updateActive) {
       let paramExists = false;
+
+      if (!activeFilter) {
+        activeFilter = {
+          filterId: filter.filterId,
+          parameters: [],
+        };
+      }
+
       const updatedParameters = activeFilter.parameters.map(param => {
         if (param.parameterName === property) {
           paramExists = true;

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -254,7 +254,7 @@ class FiltersItem extends Component {
   };
 
   handleApply = () => {
-    const { applyFilters, closeFilterMenu } = this.props;
+    const { applyFilters, closeFilterMenu, returnBackToDropdown } = this.props;
     const { filter, activeFilter } = this.state;
 
     if (
@@ -269,6 +269,7 @@ class FiltersItem extends Component {
 
     applyFilters(activeFilter, () => {
       closeFilterMenu();
+      returnBackToDropdown();
     });
   };
 

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -25,7 +25,6 @@ class FiltersItem extends Component {
     let activeFilter = null;
     if (active) {
       activeFilter = active.find(item => item.filterId === data.filterId);
-      // activeFilter = _.cloneDeep(activeFilter);
     }
 
     this.state = {
@@ -98,11 +97,7 @@ class FiltersItem extends Component {
 
     if (filter.parameters) {
       filter.parameters.map(item => {
-        // if (item.defaultValue !== undefined) {
-        //   this.mergeData(item.parameterName, '', '', true);
-        // } else {
-          this.mergeData(item.parameterName, '');
-        // }
+        this.mergeData(item.parameterName, '');
       });
 
       if (
@@ -123,10 +118,10 @@ class FiltersItem extends Component {
     }
   };
 
-  setValue = (filterId, defaultValue, property, value, id, valueTo) => {
+  setValue = (property, value, id, valueTo='', filterId, defaultValue) => {
     const { resetInitialValues } = this.props;
 
-    if (defaultValue !== undefined) {
+    if (defaultValue != null) {
       resetInitialValues(filterId, property);
     }
 
@@ -153,12 +148,11 @@ class FiltersItem extends Component {
     return value;
   };
 
-  mergeData = (property, value, valueTo, updateActive, activeValue) => { //updateActive) => {
+  mergeData = (property, value, valueTo, updateActive, activeValue) => {
     let { activeFilter, filter } = this.state;
 
     // update values for active filters, as we then bubble them up to parent
     // components which use this data in PATCH requests
-    // if (updateActive) {
     if (updateActive) {
       let paramExists = false;
 
@@ -176,7 +170,6 @@ class FiltersItem extends Component {
           return {
             ...param,
             value: this.parseDateToReadable(param.widgetType, activeValue),
-            // valueTo: this.parseDateToReadable(param.widgetType, valueTo),
           };
         } else {
           return param;
@@ -187,7 +180,6 @@ class FiltersItem extends Component {
         updatedParameters.push({
           parameterName: property,
           value: activeValue,
-          // valueTo,
         });
       }
 
@@ -197,36 +189,11 @@ class FiltersItem extends Component {
       };
     }
 
-    // console.log('mergeData activeFilter: ', {...activeFilter});
-    console.log('FI mergeData')
-
     this.setState(prevState => ({
       filter: {
         ...prevState.filter,
         parameters: prevState.filter.parameters.map(param => {
           if (param.parameterName === property) {
-          // if (param.defaultValue) {
-          //   console.log('merging: ', param, value, property)
-          // }
-          // if (param.defaultValue && param.defaultValue === value) {
-          //   return param;
-          // }
-          /*
-            const nulledFilter = initialValuesNulled.get(filterId);
-
-            if (!defaultValue || (nulledFilter && nulledFilter.has(parameterName))) {
-              continue;
-            } else if (defaultValue && (!activeFilters || !activeFilters.size)) {
-              // console.log('no active filters yet: ', parameterName, defaultValue);
-              activeFilters = Map({
-                [`${filterId}`]: {
-                  filterId,
-                  parameters: [],
-                },
-              });
-            }
-            */
-
             return {
               ...param,
               value: this.parseDateToReadable(param.widgetType, value),
@@ -264,8 +231,6 @@ class FiltersItem extends Component {
     ) {
       return this.handleClear();
     }
-
-    console.log('handleapply')
 
     applyFilters(activeFilter, () => {
       closeFilterMenu();
@@ -354,13 +319,25 @@ class FiltersItem extends Component {
                       subentity="filter"
                       subentityId={filter.filterId}
                       handlePatch={(property, value, id, valueTo) =>
-                        this.setValue(filter.filterId, item.defaultValue, property, value, id, valueTo)
+                        this.setValue(
+                          property,
+                          value,
+                          id,
+                          valueTo,
+                          filter.filterId,
+                          item.defaultValue
+                        )
                       }
                       handleChange={(property, value, id, valueTo) =>
-                        this.setValue(filter.filterId, item.defaultValue, property, value, id, valueTo)
+                        this.setValue(
+                          property,
+                          value,
+                          id,
+                          valueTo,
+                          filter.filterId,
+                          item.defaultValue
+                        )
                       }
-                      _handlePatch={this.setValue}
-                      _handleChange={this.setValue}
                       widgetType={item.widgetType}
                       fields={[item]}
                       type={item.type}

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -152,6 +152,7 @@ FiltersNotFrequent.propTypes = {
   allowOutsideClick: PropTypes.bool.isRequired,
   modalVisible: PropTypes.bool.isRequired,
   filtersWrapper: PropTypes.any,
+  activeFiltersCaptions: PropTypes.array,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -2,6 +2,7 @@ import counterpart from 'counterpart';
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 import { getItemsByProperty } from '../../actions/WindowActions';
@@ -62,11 +63,12 @@ class FiltersNotFrequent extends Component {
     const activeFilters = data.filter(filter => filter.isActive);
     const activeFilter = activeFilters.length === 1 && activeFilters[0];
 
-    let captions = activeFilter
-      ? activeFiltersCaptions[activeFilter.filterId]
-      : 'Filter';
+    let captions =
+      activeFilter && activeFiltersCaptions[activeFilter.filterId]
+        ? activeFiltersCaptions[activeFilter.filterId]
+        : 'Filter';
     let panelCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
-    let buttonCaption = activeFilter.caption;
+    let buttonCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
 
     if (captions.splice) {
       buttonCaption = captions[0];
@@ -77,12 +79,15 @@ class FiltersNotFrequent extends Component {
       <div className="filter-wrapper">
         <button
           onClick={() => this.toggleDropdown(true)}
-          className={
-            'btn btn-filter btn-meta-outline-secondary ' +
-            'btn-distance btn-sm' +
-            (isOpenDropdown ? ' btn-select' : '') +
-            (activeFilters.length > 0 ? ' btn-active' : '')
-          }
+          className={classnames(
+            'btn btn-filter btn-meta-outline-secondary',
+            'btn-distance btn-sm',
+            {
+              'btn-select': isOpenDropdown,
+              'btn-active': activeFilters.length > 0,
+            }
+          )}
+          title={buttonCaption}
           tabIndex={modalVisible ? -1 : 0}
         >
           <i className="meta-icon-preview" />

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -152,7 +152,7 @@ FiltersNotFrequent.propTypes = {
   allowOutsideClick: PropTypes.bool.isRequired,
   modalVisible: PropTypes.bool.isRequired,
   filtersWrapper: PropTypes.any,
-  activeFiltersCaptions: PropTypes.array,
+  activeFiltersCaptions: PropTypes.object,
 };
 
 const mapStateToProps = state => {

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -56,6 +56,7 @@ class FiltersNotFrequent extends Component {
       active,
       modalVisible,
       activeFiltersCaptions,
+      resetInitialValues,
     } = this.props;
 
     const { isOpenDropdown, openFilterId } = this.state;
@@ -122,20 +123,23 @@ class FiltersNotFrequent extends Component {
               </ul>
             ) : (
               <FiltersItem
+                {...{
+                  panelCaption,
+                  windowType,
+                  active,
+                  viewId,
+                  resetInitialValues,
+                  applyFilters,
+                  clearFilters,
+                }}
                 captionValue={activeFilter.captionValue}
-                panelCaption={panelCaption}
-                windowType={windowType}
                 data={activeFilter.isActive ? activeFilter : openFilter}
                 closeFilterMenu={() => this.toggleDropdown(false)}
                 returnBackToDropdown={() => this.toggleFilter(null)}
-                clearFilters={clearFilters}
-                applyFilters={applyFilters}
                 notValidFields={notValidFields}
                 isActive={activeFilter.isActive}
-                active={active}
                 onShow={() => handleShow(true)}
                 onHide={() => handleShow(false)}
-                viewId={viewId}
                 outsideClick={this.outsideClick}
                 openedFilter={true}
                 filtersWrapper={this.props.filtersWrapper}
@@ -150,13 +154,14 @@ class FiltersNotFrequent extends Component {
 
 FiltersNotFrequent.propTypes = {
   allowOutsideClick: PropTypes.bool.isRequired,
+  resetInitialValues: PropTypes.func.isRequired,
   modalVisible: PropTypes.bool.isRequired,
   filtersWrapper: PropTypes.any,
   activeFiltersCaptions: PropTypes.object,
 };
 
-const mapStateToProps = state => {
-  const { allowOutsideClick, modal } = state.windowHandler;
+const mapStateToProps = ({ windowHandler }) => {
+  const { allowOutsideClick, modal } = windowHandler;
 
   return {
     allowOutsideClick,

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -63,14 +63,12 @@ class FiltersNotFrequent extends Component {
     const activeFilters = data.filter(filter => filter.isActive);
     const activeFilter = activeFilters.length === 1 && activeFilters[0];
 
-    let captions =
-      activeFilter && activeFiltersCaptions[activeFilter.filterId]
-        ? activeFiltersCaptions[activeFilter.filterId]
-        : 'Filter';
+    const captions =
+      (activeFilter && activeFiltersCaptions[activeFilter.filterId]) || [];
     let panelCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
     let buttonCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
 
-    if (captions.splice) {
+    if (captions.length) {
       buttonCaption = captions[0];
       panelCaption = captions[1];
     }
@@ -84,7 +82,7 @@ class FiltersNotFrequent extends Component {
             'btn-distance btn-sm',
             {
               'btn-select': isOpenDropdown,
-              'btn-active': activeFilters.length > 0,
+              'btn-active': captions.length,
             }
           )}
           title={buttonCaption}

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -54,6 +54,7 @@ class FiltersNotFrequent extends Component {
       clearFilters,
       active,
       modalVisible,
+      activeFiltersCaptions,
     } = this.props;
 
     const { isOpenDropdown, openFilterId } = this.state;
@@ -61,9 +62,15 @@ class FiltersNotFrequent extends Component {
     const activeFilters = data.filter(filter => filter.isActive);
     const activeFilter = activeFilters.length === 1 && activeFilters[0];
 
-    let caption = activeFilter ? activeFilter.caption : 'Filter';
-    if (activeFilter.captionValue && activeFilter.captionValue.length) {
-      caption = activeFilter.captionValue;
+    let captions = activeFilter
+      ? activeFiltersCaptions[activeFilter.filterId]
+      : 'Filter';
+    let panelCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
+    let buttonCaption = activeFilter.caption;
+
+    if (captions.splice) {
+      buttonCaption = captions[0];
+      panelCaption = captions[1];
     }
 
     return (
@@ -88,7 +95,9 @@ class FiltersNotFrequent extends Component {
                 {activeFilter.captionValue}
               </Fragment>
             ) : (
-              `${counterpart.translate('window.filters.caption2')}: ${caption}`
+              `${counterpart.translate(
+                'window.filters.caption2'
+              )}: ${buttonCaption}`
             )
           ) : (
             'Filter'
@@ -111,6 +120,7 @@ class FiltersNotFrequent extends Component {
             ) : (
               <FiltersItem
                 captionValue={activeFilter.captionValue}
+                panelCaption={panelCaption}
                 windowType={windowType}
                 data={activeFilter.isActive ? activeFilter : openFilter}
                 closeFilterMenu={() => this.toggleDropdown(false)}

--- a/src/utils/documentListHelper.js
+++ b/src/utils/documentListHelper.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import { push } from 'react-router-redux';
-import {
-  getItemsByProperty,
-  mapIncluded,
-} from '../actions/WindowActions';
+import { Map } from 'immutable';
+import { getItemsByProperty, mapIncluded } from '../actions/WindowActions';
 import { getSelection } from '../reducers/windowHandler';
 
 const DLpropTypes = {
@@ -55,12 +53,16 @@ const NO_SELECTION = [];
 const NO_VIEW = {};
 const PANEL_WIDTHS = ['1', '.2', '4'];
 
-const filtersToObject = function(filtersArray) {
-  if (filtersArray && filtersArray.length) {
+const filtersToMap = function(filtersArray) {
+  let filtersMap = Map();
 
+  if (filtersArray && filtersArray.length) {
+    filtersArray.forEach(filter => {
+      filtersMap = filtersMap.set(filter.filterId, filter);
+    });
   }
 
-  return null;
+  return filtersMap;
 };
 
 const doesSelectionExist = function({
@@ -111,6 +113,6 @@ export {
   PANEL_WIDTHS,
   getSortingQuery,
   redirectToNewDocument,
-  filtersToObject,
+  filtersToMap,
   doesSelectionExist,
 };

--- a/src/utils/documentListHelper.js
+++ b/src/utils/documentListHelper.js
@@ -1,0 +1,116 @@
+import PropTypes from 'prop-types';
+import { push } from 'react-router-redux';
+import {
+  getItemsByProperty,
+  mapIncluded,
+} from '../actions/WindowActions';
+import { getSelection } from '../reducers/windowHandler';
+
+const DLpropTypes = {
+  // from parent
+  windowType: PropTypes.string.isRequired,
+
+  // from <DocList>
+  updateParentSelectedIds: PropTypes.func,
+
+  // from @connect
+  dispatch: PropTypes.func.isRequired,
+  selections: PropTypes.object.isRequired,
+  childSelected: PropTypes.array.isRequired,
+  parentSelected: PropTypes.array.isRequired,
+  selected: PropTypes.array.isRequired,
+  isModal: PropTypes.bool,
+};
+
+const DLcontextTypes = {
+  store: PropTypes.object.isRequired,
+};
+
+const DLmapStateToProps = (state, props) => ({
+  selections: state.windowHandler.selections,
+  selected: getSelection({
+    state,
+    windowType: props.windowType,
+    viewId: props.defaultViewId,
+  }),
+  childSelected:
+    props.includedView && props.includedView.windowType
+      ? getSelection({
+          state,
+          windowType: props.includedView.windowType,
+          viewId: props.includedView.viewId,
+        })
+      : NO_SELECTION,
+  parentSelected: props.parentWindowType
+    ? getSelection({
+        state,
+        windowType: props.parentWindowType,
+        viewId: props.parentDefaultViewId,
+      })
+    : NO_SELECTION,
+  modal: state.windowHandler.modal,
+});
+
+const NO_SELECTION = [];
+const NO_VIEW = {};
+const PANEL_WIDTHS = ['1', '.2', '4'];
+
+const filtersToObject = function(filtersArray) {
+  if (filtersArray && filtersArray.length) {
+
+  }
+
+  return null;
+};
+
+const doesSelectionExist = function({
+  data,
+  selected,
+  hasIncluded = false,
+} = {}) {
+  // When the rows are changing we should ensure
+  // that selection still exist
+  if (hasIncluded) {
+    return true;
+  }
+
+  if (selected && selected[0] === 'all') {
+    return true;
+  }
+
+  let rows = [];
+
+  data &&
+    data.result &&
+    data.result.map(item => {
+      rows = rows.concat(mapIncluded(item));
+    });
+
+  return (
+    data &&
+    data.size &&
+    data.result &&
+    selected &&
+    selected[0] &&
+    getItemsByProperty(rows, 'id', selected[0]).length
+  );
+};
+
+const redirectToNewDocument = (dispatch, windowType) => {
+  dispatch(push(`/window/${windowType}/new`));
+};
+
+const getSortingQuery = (asc, field) => (asc ? '+' : '-') + field;
+
+export {
+  DLpropTypes,
+  DLcontextTypes,
+  DLmapStateToProps,
+  NO_SELECTION,
+  NO_VIEW,
+  PANEL_WIDTHS,
+  getSortingQuery,
+  redirectToNewDocument,
+  filtersToObject,
+  doesSelectionExist,
+};

--- a/src/utils/documentListHelper.js
+++ b/src/utils/documentListHelper.js
@@ -58,7 +58,12 @@ const filtersToMap = function(filtersArray) {
 
   if (filtersArray && filtersArray.length) {
     filtersArray.forEach(filter => {
-      filtersMap = filtersMap.set(filter.filterId, filter);
+      if (
+        !filter.parameters ||
+        (filter.parameters && filter.parameters.length)
+      ) {
+        filtersMap = filtersMap.set(filter.filterId, filter);
+      }
     });
   }
 


### PR DESCRIPTION
Properly selects and indicates active/not active filters, supports `defaultValue`, for not frequent filters allows showing captions for all selected filters instead of `Default` (which doesn't make sense). Plus a lot of cleanup and fixing data stored/sent to the server.
Related to #1944 & #1948 