### PR TITLE
Revert "Show description instead of caption for fields tooltips"

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -816,7 +816,6 @@ class RawWidget extends Component {
   render() {
     const {
       caption,
-      description,
       captionElement,
       fields,
       type,
@@ -871,8 +870,7 @@ class RawWidget extends Component {
       >
         {captionElement || null}
         {!noLabel &&
-          caption &&
-          description && (
+          caption && (
             <div
               key="title"
               className={
@@ -881,7 +879,7 @@ class RawWidget extends Component {
                   ? 'col-sm-12 panel-title'
                   : type === 'primaryLongLabels' ? 'col-sm-6' : 'col-sm-3 ')
               }
-              title={description}
+              title={caption}
             >
               {fields[0].supportZoomInto ? (
                 <span


### PR DESCRIPTION
Reverts metasfresh/metasfresh-webui-frontend#1954