### PR TITLE
Fixes for filters

### DIFF
--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -50,7 +50,7 @@ class Filters extends Component {
             });
           }
 
-          const isActive = activeFilters.has(filterId);
+          const isActive = filtersActive.has(filterId);
 
           if (
             !defaultValue ||

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -156,7 +156,14 @@ class FiltersItem extends Component {
     return value;
   };
 
-  mergeData = (property, value, valueTo, updateActive, activeValue, activeValueTo) => {
+  mergeData = (
+    property,
+    value,
+    valueTo,
+    updateActive,
+    activeValue,
+    activeValueTo
+  ) => {
     let { activeFilter, filter } = this.state;
 
     // update values for active filters, as we then bubble them up to parent

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -130,7 +130,7 @@ class FiltersItem extends Component {
     const { resetInitialValues } = this.props;
 
     if (defaultValue != null) {
-      resetInitialValues(filterId, property);
+      resetInitialValues && resetInitialValues(filterId, property);
     }
 
     //TODO: LOOKUPS GENERATE DIFFERENT TYPE OF PROPERTY parameters
@@ -265,7 +265,7 @@ class FiltersItem extends Component {
     } = this.props;
     const { filter } = this.state;
 
-    resetInitialValues(filter.filterId);
+    resetInitialValues && resetInitialValues(filter.filterId);
     clearFilters(filter);
     closeFilterMenu();
     returnBackToDropdown && returnBackToDropdown();

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -102,7 +102,8 @@ class FiltersItem extends Component {
           '',
           '',
           item.defaultValue ? true : false,
-          item.defaultValue
+          item.defaultValue,
+          item.defaultValueTo
         );
       });
 
@@ -117,7 +118,8 @@ class FiltersItem extends Component {
             item.value != null ? item.value : '',
             item.valueTo != null ? item.valueTo : '',
             true,
-            item.value !== undefined ? item.value : item.defaultValue
+            item.value !== undefined ? item.value : item.defaultValue,
+            item.valueTo !== undefined ? item.valueTo : item.defaultValueTo
           );
         });
       }
@@ -154,7 +156,7 @@ class FiltersItem extends Component {
     return value;
   };
 
-  mergeData = (property, value, valueTo, updateActive, activeValue) => {
+  mergeData = (property, value, valueTo, updateActive, activeValue, activeValueTo) => {
     let { activeFilter, filter } = this.state;
 
     // update values for active filters, as we then bubble them up to parent
@@ -176,12 +178,15 @@ class FiltersItem extends Component {
           return {
             ...param,
             value: this.parseDateToReadable(param.widgetType, activeValue),
+            valueTo: this.parseDateToReadable(param.widgetType, activeValueTo),
             defaultValue: null,
+            defaultValueTo: null,
           };
         } else {
           return {
             ...param,
             defaultValue: null,
+            defaultValueTo: null,
           };
         }
       });
@@ -190,7 +195,9 @@ class FiltersItem extends Component {
         updatedParameters.push({
           parameterName: property,
           value: activeValue,
+          valueTo: activeValueTo,
           defaultValue: null,
+          defaultValueTo: null,
         });
       }
 
@@ -245,7 +252,7 @@ class FiltersItem extends Component {
 
     applyFilters(activeFilter, () => {
       closeFilterMenu();
-      returnBackToDropdown();
+      returnBackToDropdown && returnBackToDropdown();
     });
   };
 
@@ -428,7 +435,7 @@ class FiltersItem extends Component {
 FiltersItem.propTypes = {
   dispatch: PropTypes.func.isRequired,
   applyFilters: PropTypes.func.isRequired,
-  resetInitialValues: PropTypes.func.isRequired,
+  resetInitialValues: PropTypes.func,
   clearFilters: PropTypes.func,
   filtersWrapper: PropTypes.any,
   panelCaption: PropTypes.string,

--- a/src/components/filters/FiltersNotFrequent.js
+++ b/src/components/filters/FiltersNotFrequent.js
@@ -66,7 +66,7 @@ class FiltersNotFrequent extends Component {
 
     const captions =
       (activeFilter && activeFiltersCaptions[activeFilter.filterId]) || [];
-    let panelCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
+    let panelCaption = activeFilter.isActive ? activeFilter.caption : '';
     let buttonCaption = activeFilter.isActive ? activeFilter.caption : 'Filter';
 
     if (captions.length) {


### PR DESCRIPTION
Reated to #1944 & #1948 

Fixes:
- propTypes error
- showing filter `Filter` in not-frequent filters panel even if nothing was set
- fix error in the console when resetting frequent filters
- fix error of showing inactive filter with defaultValue in caption which also blocked the filters list (issue on client's setup)