### PR TITLE
Show description for field labels

### DIFF
--- a/src/components/table/TableHeader.js
+++ b/src/components/table/TableHeader.js
@@ -57,7 +57,7 @@ class TableHeader extends PureComponent {
     deselect();
   };
 
-  renderSorting = (field, caption, sortable) => {
+  renderSorting = (field, caption, sortable, description) => {
     const { fields } = this.state;
     const fieldSorting = fields[field];
 
@@ -67,7 +67,7 @@ class TableHeader extends PureComponent {
         onClick={() => this.handleClick(field, sortable)}
       >
         <span
-          title={caption}
+          title={description || caption}
           className={classnames({ 'th-caption': sortable })}
         >
           {caption}
@@ -97,7 +97,8 @@ class TableHeader extends PureComponent {
                 ? this.renderSorting(
                     item.fields[0].field,
                     item.caption,
-                    item.sortable
+                    item.sortable,
+                    item.description
                   )
                 : item.caption}
             </th>

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -833,7 +833,6 @@ class RawWidget extends Component {
       widgetType,
       handleZoomInto,
     } = this.props;
-
     const { errorPopup, clearedFieldWarning, tooltipToggled } = this.state;
     const widgetBody = this.renderWidget();
     const { validStatus, warning } = widgetData[0];
@@ -876,8 +875,7 @@ class RawWidget extends Component {
       >
         {captionElement || null}
         {!noLabel &&
-          caption &&
-          description && (
+          caption && (
             <div
               key="title"
               className={
@@ -886,7 +884,7 @@ class RawWidget extends Component {
                   ? 'col-sm-12 panel-title'
                   : type === 'primaryLongLabels' ? 'col-sm-6' : 'col-sm-3 ')
               }
-              title={description}
+              title={description || caption}
             >
               {fields[0].supportZoomInto ? (
                 <span

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -821,6 +821,7 @@ class RawWidget extends Component {
   render() {
     const {
       caption,
+      description,
       captionElement,
       fields,
       type,
@@ -875,7 +876,8 @@ class RawWidget extends Component {
       >
         {captionElement || null}
         {!noLabel &&
-          caption && (
+          caption &&
+          description && (
             <div
               key="title"
               className={
@@ -884,7 +886,7 @@ class RawWidget extends Component {
                   ? 'col-sm-12 panel-title'
                   : type === 'primaryLongLabels' ? 'col-sm-6' : 'col-sm-3 ')
               }
-              title={caption}
+              title={description}
             >
               {fields[0].supportZoomInto ? (
                 <span


### PR DESCRIPTION
If description is not available, use caption as we do now. Related to #1953 