### PR TITLE
Fix filters without parameters

### DIFF
--- a/src/components/filters/Filters.js
+++ b/src/components/filters/Filters.js
@@ -125,7 +125,7 @@ class Filters extends Component {
       const removeDefault = {};
 
       activeFilters.forEach((filter, filterId) => {
-        const captionsArray = ['', ''];
+        let captionsArray = ['', ''];
 
         if (filter.parameters && filter.parameters.length) {
           filter.parameters.forEach(filterParameter => {
@@ -185,7 +185,8 @@ class Filters extends Component {
             }
           });
         } else {
-          activeFilters = activeFilters.delete(filterId);
+          const originalFilter = filtersData.get(filterId);
+          captionsArray = [originalFilter.caption, originalFilter.caption];
         }
 
         if (captionsArray.join('').length) {

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -436,7 +436,9 @@ class FiltersItem extends Component {
                   },
                 ]}
               >
-                {!filter.isActive && !filter.parameters ? (
+                {filter.isActive && !filter.parameters ? (
+                  <span />
+                ) : (
                   <button
                     className="applyBtn btn btn-sm btn-success"
                     onClick={this.handleApply}
@@ -445,8 +447,6 @@ class FiltersItem extends Component {
                   >
                     {counterpart.translate('window.apply.caption')}
                   </button>
-                ) : (
-                  <span />
                 )}
                 {isTooltipShow && (
                   <Tooltips

--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -269,10 +269,24 @@ class FiltersItem extends Component {
       return this.handleClear();
     }
 
-    applyFilters(activeFilter, () => {
-      closeFilterMenu();
-      returnBackToDropdown && returnBackToDropdown();
-    });
+    if (!filter.parameters) {
+      this.setState(
+        {
+          activeFilter: filter,
+        },
+        () => {
+          applyFilters(this.state.activeFilter, () => {
+            closeFilterMenu();
+            returnBackToDropdown && returnBackToDropdown();
+          });
+        }
+      );
+    } else {
+      applyFilters(activeFilter, () => {
+        closeFilterMenu();
+        returnBackToDropdown && returnBackToDropdown();
+      });
+    }
   };
 
   handleClear = () => {
@@ -422,14 +436,18 @@ class FiltersItem extends Component {
                   },
                 ]}
               >
-                <button
-                  className="applyBtn btn btn-sm btn-success"
-                  onClick={this.handleApply}
-                  onMouseEnter={() => this.toggleTooltip(true)}
-                  onMouseLeave={() => this.toggleTooltip(false)}
-                >
-                  {counterpart.translate('window.apply.caption')}
-                </button>
+                {!filter.isActive && !filter.parameters ? (
+                  <button
+                    className="applyBtn btn btn-sm btn-success"
+                    onClick={this.handleApply}
+                    onMouseEnter={() => this.toggleTooltip(true)}
+                    onMouseLeave={() => this.toggleTooltip(false)}
+                  >
+                    {counterpart.translate('window.apply.caption')}
+                  </button>
+                ) : (
+                  <span />
+                )}
                 {isTooltipShow && (
                   <Tooltips
                     className="filter-tooltip"

--- a/src/utils/documentListHelper.js
+++ b/src/utils/documentListHelper.js
@@ -58,15 +58,9 @@ const filtersToMap = function(filtersArray) {
 
   if (filtersArray && filtersArray.length) {
     filtersArray.forEach(filter => {
-      if (
-        !filter.parameters ||
-        (filter.parameters && filter.parameters.length)
-      ) {
-        filtersMap = filtersMap.set(filter.filterId, filter);
-      }
+      filtersMap = filtersMap.set(filter.filterId, filter);
     });
   }
-
   return filtersMap;
 };
 


### PR DESCRIPTION
User defined filters will now properly indicate their active state (and hide other filter options) and the apply button is removed when filter is active (as it wasn't doing anything - clear filter is used for deactivating instead).

Related to #1972 