### PR TITLE
Apply clearing lookup field only when request succeeded

### DIFF
--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -796,6 +796,7 @@ input[type=checkbox]:disabled, input[type=radio]:disabled {
 .lookup-tooltip {
     flex: 0.05;
     justify-content: flex-end;
+    pointer-events: initial;
 }
 
 /* Attributes */

--- a/src/components/app/Indicator.js
+++ b/src/components/app/Indicator.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 class Indicator extends Component {
@@ -24,10 +25,10 @@ class Indicator extends Component {
     return (
       <div>
         <div
-          className={
-            'indicator-bar ' +
-            (isDocumentNotSaved ? 'indicator-error ' : 'indicator-' + indicator)
-          }
+          className={classnames('indicator-bar', {
+            'indicator-error': isDocumentNotSaved,
+            [`${indicator}-indicator`]: !isDocumentNotSaved,
+          })}
         />
       </div>
     );

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -244,17 +244,23 @@ class Lookup extends Component {
   // TODO: Rewrite per widget
   handleClear = () => {
     const { onChange, properties, onSelectBarcode } = this.props;
+    const onChangeResp = onChange && onChange(properties, null, false);
 
-    onChange && onChange(properties, null, false);
-    onSelectBarcode && onSelectBarcode(null);
+    if (onChangeResp && onChangeResp.then) {
+      onChangeResp.then(resp => {
+        if (resp) {
+          onSelectBarcode && onSelectBarcode(null);
 
-    this.setState({
-      isInputEmpty: true,
-      property: '',
-      initialFocus: true,
-      localClearing: true,
-      autofocusDisabled: false,
-    });
+          this.setState({
+            isInputEmpty: true,
+            property: '',
+            initialFocus: true,
+            localClearing: true,
+            autofocusDisabled: false,
+          });
+        }
+      });
+    }
   };
 
   handleListFocus = field => {

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -244,7 +244,11 @@ class Lookup extends Component {
   // TODO: Rewrite per widget
   handleClear = () => {
     const { onChange, properties, onSelectBarcode } = this.props;
-    const onChangeResp = onChange && onChange(properties, null, false);
+    const propsWithoutTooltips = properties.filter(
+      prop => prop.type !== 'Tooltip'
+    );
+    const onChangeResp =
+      onChange && onChange(propsWithoutTooltips, null, false);
 
     if (onChangeResp && onChangeResp.then) {
       onChangeResp.then(resp => {

--- a/src/components/widget/WidgetTooltip.js
+++ b/src/components/widget/WidgetTooltip.js
@@ -62,6 +62,7 @@ WidgetTooltip.propTypes = {
   widget: PropTypes.any.isRequired,
   data: PropTypes.any.isRequired,
   isToggled: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func,
 };
 
 export default onClickOutside(WidgetTooltip);

--- a/src/components/widget/WidgetTooltip.js
+++ b/src/components/widget/WidgetTooltip.js
@@ -39,7 +39,7 @@ class WidgetTooltip extends PureComponent {
             )}
           </Reference>
           {isToggled && (
-            <Popper placement="right">
+            <Popper placement="right-start">
               {({ ref, style, placement }) => (
                 <div
                   ref={ref}


### PR DESCRIPTION
Right now fields are cleared even if backend responded with an error (so data wasn't actually altered in any way). We should wait for a positive response instead (a good use case is clearing business partner in `/window/143/<id>`)

Related to #1950 

Update:
Related to metasfresh/metasfresh#4630