### PR TITLE
Tooltip widgets should be displayed without edit mode too

### DIFF
--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -796,6 +796,7 @@ input[type=checkbox]:disabled, input[type=radio]:disabled {
 .lookup-tooltip {
     flex: 0.05;
     justify-content: flex-end;
+    pointer-events: initial;
 }
 
 /* Attributes */

--- a/src/assets/css/table.css
+++ b/src/assets/css/table.css
@@ -130,6 +130,15 @@
                 }
             }
         }
+
+        .with-widget {
+            display: flex;
+            align-items: end;
+
+            .widget-tooltip {
+                flex: 1 1 20px;
+            }
+        }
     }
 
     /* Table cols sizing */

--- a/src/components/app/Indicator.js
+++ b/src/components/app/Indicator.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import { connect } from 'react-redux';
 
 class Indicator extends Component {
@@ -24,10 +25,10 @@ class Indicator extends Component {
     return (
       <div>
         <div
-          className={
-            'indicator-bar ' +
-            (isDocumentNotSaved ? 'indicator-error ' : 'indicator-' + indicator)
-          }
+          className={classnames('indicator-bar', {
+            'indicator-error': isDocumentNotSaved,
+            [`${indicator}-indicator`]: !isDocumentNotSaved,
+          })}
         />
       </div>
     );

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -13,7 +13,6 @@ import {
   DATE_FIELD_TYPES,
   DATE_FIELD_FORMATS,
 } from '../../constants/Constants';
-import { getItemsByProperty } from '../../actions/WindowActions';
 import WidgetTooltip from '../widget/WidgetTooltip';
 
 class TableCell extends PureComponent {

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -13,6 +13,8 @@ import {
   DATE_FIELD_TYPES,
   DATE_FIELD_FORMATS,
 } from '../../constants/Constants';
+import { getItemsByProperty } from '../../actions/WindowActions';
+import WidgetTooltip from '../widget/WidgetTooltip';
 
 class TableCell extends PureComponent {
   static getAmountFormatByPrecision = precision =>
@@ -101,6 +103,14 @@ class TableCell extends PureComponent {
     }
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      tooltipToggled: false,
+    };
+  }
+
   componentWillReceiveProps(nextProps) {
     const { widgetData, updateRow, readonly, rowId } = this.props;
     // We should avoid highlighting when whole row is exchanged (sorting)
@@ -116,6 +126,15 @@ class TableCell extends PureComponent {
       updateRow();
     }
   }
+
+  widgetTooltipToggle = (field, value) => {
+    const curVal = this.state.tooltipToggled;
+    const newVal = value != null ? value : !curVal;
+
+    this.setState({
+      tooltipToggled: newVal,
+    });
+  };
 
   handleBackdropLock = state => {
     const { item } = this.props;
@@ -159,6 +178,7 @@ class TableCell extends PureComponent {
       onClickOutside,
     } = this.props;
     const docId = `${this.props.docId}`;
+    const { tooltipToggled } = this.state;
     const tdValue = !isEdited
       ? TableCell.fieldValueToString(
           widgetData[0].value,
@@ -171,6 +191,17 @@ class TableCell extends PureComponent {
       ? TableCell.getDateFormat(item.widgetType)
       : false;
     let style = {};
+    let tooltipData = null;
+    let tooltipWidget =
+      item.fields && item.widgetType === 'Lookup'
+        ? item.fields.find((field, idx) => {
+            if (field.type === 'Tooltip') {
+              tooltipData = widgetData[idx];
+              return field;
+            }
+            return false;
+          })
+        : null;
 
     if (cellExtended) {
       style = {
@@ -226,21 +257,32 @@ class TableCell extends PureComponent {
             }}
           />
         ) : (
-          <div
-            className={classnames('cell-text-wrapper', {
-              [`${item.widgetType.toLowerCase()}-cell`]: item.widgetType,
-              extended: cellExtended,
-            })}
-            style={style}
-            title={
-              item.widgetType === 'YesNo' ||
-              item.widgetType === 'Switch' ||
-              item.widgetType === 'Color'
-                ? ''
-                : tdValue
-            }
-          >
-            {tdValue}
+          <div className={classnames({ 'with-widget': tooltipWidget })}>
+            <div
+              className={classnames('cell-text-wrapper', {
+                [`${item.widgetType.toLowerCase()}-cell`]: item.widgetType,
+                extended: cellExtended,
+              })}
+              style={style}
+              title={
+                item.widgetType === 'YesNo' ||
+                item.widgetType === 'Switch' ||
+                item.widgetType === 'Color'
+                  ? ''
+                  : tdValue
+              }
+            >
+              {tdValue}
+            </div>
+            {tooltipWidget &&
+              !isEdited && (
+                <WidgetTooltip
+                  widget={tooltipWidget}
+                  data={tooltipData}
+                  isToggled={tooltipToggled}
+                  onToggle={val => this.widgetTooltipToggle(item.field, val)}
+                />
+              )}
           </div>
         )}
       </td>

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -244,17 +244,23 @@ class Lookup extends Component {
   // TODO: Rewrite per widget
   handleClear = () => {
     const { onChange, properties, onSelectBarcode } = this.props;
+    const onChangeResp = onChange && onChange(properties, null, false);
 
-    onChange && onChange(properties, null, false);
-    onSelectBarcode && onSelectBarcode(null);
+    if (onChangeResp && onChangeResp.then) {
+      onChangeResp.then(resp => {
+        if (resp) {
+          onSelectBarcode && onSelectBarcode(null);
 
-    this.setState({
-      isInputEmpty: true,
-      property: '',
-      initialFocus: true,
-      localClearing: true,
-      autofocusDisabled: false,
-    });
+          this.setState({
+            isInputEmpty: true,
+            property: '',
+            initialFocus: true,
+            localClearing: true,
+            autofocusDisabled: false,
+          });
+        }
+      });
+    }
   };
 
   handleListFocus = field => {

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -244,7 +244,11 @@ class Lookup extends Component {
   // TODO: Rewrite per widget
   handleClear = () => {
     const { onChange, properties, onSelectBarcode } = this.props;
-    const onChangeResp = onChange && onChange(properties, null, false);
+    const propsWithoutTooltips = properties.filter(
+      prop => prop.type !== 'Tooltip'
+    );
+    const onChangeResp =
+      onChange && onChange(propsWithoutTooltips, null, false);
 
     if (onChangeResp && onChangeResp.then) {
       onChangeResp.then(resp => {

--- a/src/components/widget/WidgetTooltip.js
+++ b/src/components/widget/WidgetTooltip.js
@@ -62,6 +62,7 @@ WidgetTooltip.propTypes = {
   widget: PropTypes.any.isRequired,
   data: PropTypes.any.isRequired,
   isToggled: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func,
 };
 
 export default onClickOutside(WidgetTooltip);

--- a/src/components/widget/WidgetTooltip.js
+++ b/src/components/widget/WidgetTooltip.js
@@ -39,7 +39,7 @@ class WidgetTooltip extends PureComponent {
             )}
           </Reference>
           {isToggled && (
-            <Popper placement="right-start">
+            <Popper placement="auto-start">
               {({ ref, style, placement }) => (
                 <div
                   ref={ref}

--- a/src/components/widget/WidgetTooltip.js
+++ b/src/components/widget/WidgetTooltip.js
@@ -39,7 +39,7 @@ class WidgetTooltip extends PureComponent {
             )}
           </Reference>
           {isToggled && (
-            <Popper placement="right">
+            <Popper placement="right-start">
               {({ ref, style, placement }) => (
                 <div
                   ref={ref}


### PR DESCRIPTION
If cell is not edited tooltip widget will still be shown (if available) and it's toggle will be controlled by the TableCell copmonent. In edit mode everything reverts back to the way it was before. 

Related to #1985 .

![screen shot 2018-10-01 at 20 01 28](https://user-images.githubusercontent.com/513460/46306689-40b29d00-c5b5-11e8-9d01-4115ba985c0e.png)

**It'd be best to merge #1977 before, as this relies on some of the work done there.**