### PR TITLE
New cypress commands for composite lookups and quick actions

### DIFF
--- a/cypress/integration/manufacturing_order_spec.js
+++ b/cypress/integration/manufacturing_order_spec.js
@@ -1,0 +1,13 @@
+describe('Manufacturing order Test', function() {
+  before(function() {
+    cy.loginByForm();
+  });
+
+  it('Test if Barcode widget shows up', function() {
+    cy.visit('/window/53009');
+
+    cy.executeQuickAction('ADP_540788');
+
+    cy.get('.form-field-Barcode').should('exist');
+  });
+});

--- a/cypress/integration/sales_order_spec.js
+++ b/cypress/integration/sales_order_spec.js
@@ -51,17 +51,9 @@ describe('New sales order test', function() {
     });
 
     it('Fill Business Partner', function() {
-      cy.get('.input-dropdown-container .raw-lookup-wrapper')
-        .first()
-        .find('input')
-        .clear()
-        .type('G0001');
-
-      cy.get('.input-dropdown-list').should('exist');
-      cy.contains('.input-dropdown-list-option', 'Test Kunde 1').click();
-      cy
-        .get('.input-dropdown-list .input-dropdown-list-header')
-        .should('not.exist');
+      cy.writeIntoCompositeLookupField('C_BPartner_ID', 'G0001', 'Test Kunde 1');
+      cy.get('#lookup_C_BPartner_ID').click();
+      cy.writeIntoCompositeLookupField('C_BPartner_Location_ID', 'test', 'Testadresse 3');
 
       cy.get('.header-breadcrumb-sitename').should('not.contain', '<');
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -153,18 +153,13 @@ Cypress.Commands.add(
   (fieldName, partialValue, listValue) => {
     describe('Enter value into lookup list field', function() {
       cy.get(`#lookup_${fieldName}`)
-        .then((el) => {
-          if (el.find('.raw-lookup-wrapper input').length) {
-            return el.find('input')[0].type(partialValue);
+        .within(($el) => {
+          if ($el.find('.raw-lookup-wrapper input').length) {
+            return cy.get('input').type(partialValue);
           }
 
-            return cy.get('.lookup-dropdown').click();
-          
+          return cy.get('.lookup-dropdown').click();
         })
-        
-
-      // input-dropdown-container lookup-dropdown
-
 
       cy.get('.input-dropdown-list').should('exist');
       cy.contains('.input-dropdown-list-option', listValue).click();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -235,8 +235,11 @@ Cypress.Commands.add('selectTab', (tabName) => {
   });
 });
 
-Cypress.Commands.add('', (tabName) => {
-  describe('Select and activate the tab with a certain name', function() {
-    return cy.get(`#tab_${tabName}`).click()
+Cypress.Commands.add('executeQuickAction', (actionName) => {
+  describe('Fire a quick action with a certain name', function() {
+    cy.get('.quick-actions-wrapper').click();
+    cy.get('.quick-actions-dropdown').should('exist');
+
+    return cy.get(`#quickAction_${actionName}`).click()
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -235,11 +235,17 @@ Cypress.Commands.add('selectTab', (tabName) => {
   });
 });
 
-Cypress.Commands.add('executeQuickAction', (actionName) => {
+// This command runs a quick actions. If second parameter is truthy, the default action
+// will be executed.
+Cypress.Commands.add('executeQuickAction', (actionName, active) => {
   describe('Fire a quick action with a certain name', function() {
-    cy.get('.quick-actions-wrapper').click();
-    cy.get('.quick-actions-dropdown').should('exist');
+    if (!active) {
+      cy.get('.quick-actions-wrapper .btn-inline').click();
+      cy.get('.quick-actions-dropdown').should('exist');
 
-    return cy.get(`#quickAction_${actionName}`).click()
+      return cy.get(`#quickAction_${actionName}`).click();
+    }
+
+    return cy.get('.quick-actions-wrapper').click();
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -148,6 +148,30 @@ Cypress.Commands.add(
     });
 });
 
+Cypress.Commands.add(
+  'writeIntoCompositeLookupField',
+  (fieldName, partialValue, listValue) => {
+    describe('Enter value into lookup list field', function() {
+      cy.get(`#lookup_${fieldName}`)
+        .then((el) => {
+          if (el.find('.raw-lookup-wrapper input').length) {
+            return el.find('input')[0].type(partialValue);
+          }
+
+            return cy.get('.lookup-dropdown').click();
+          
+        })
+        
+
+      // input-dropdown-container lookup-dropdown
+
+
+      cy.get('.input-dropdown-list').should('exist');
+      cy.contains('.input-dropdown-list-option', listValue).click();
+      cy.get('.input-dropdown-list .input-dropdown-list-header').should('not.exist');
+    });
+});
+
 Cypress.Commands.add('selectInListField', (fieldName, listValue) => {
   describe('Select value in list field', function() {
       cy.get(`.form-field-${fieldName}`)
@@ -211,6 +235,12 @@ Cypress.Commands.add('openAdvancedEdit', () => {
 });
 
 Cypress.Commands.add('selectTab', (tabName) => {
+  describe('Select and activate the tab with a certain name', function() {
+    return cy.get(`#tab_${tabName}`).click()
+  });
+});
+
+Cypress.Commands.add('', (tabName) => {
   describe('Select and activate the tab with a certain name', function() {
     return cy.get(`#tab_${tabName}`).click()
   });

--- a/src/components/app/QuickActionsDropdown.js
+++ b/src/components/app/QuickActionsDropdown.js
@@ -55,6 +55,9 @@ class QuickActionsDropdown extends Component {
       <div className="quick-actions-dropdown">
         {actions.map((action, index) => (
           <div
+            id={`quickAction_${
+              action.internalName ? action.internalName : action.processId
+            }`}
             tabIndex={0}
             ref={c => (this.item = c)}
             className={

--- a/src/components/widget/Lookup/Lookup.js
+++ b/src/components/widget/Lookup/Lookup.js
@@ -416,6 +416,7 @@ class Lookup extends Component {
               item.field
             )[0];
             const widgetTooltipToggled = lookupWidget.tooltipOpen;
+            const idValue = `lookup_${item.field}`;
 
             if (item.type === 'Tooltip') {
               if (!itemByProperty.value) {
@@ -425,6 +426,7 @@ class Lookup extends Component {
               return (
                 <div
                   key={item.field}
+                  id={idValue}
                   className="raw-lookup-wrapper lookup-tooltip"
                 >
                   <WidgetTooltip
@@ -456,6 +458,7 @@ class Lookup extends Component {
               return (
                 <RawLookup
                   key={index}
+                  idValue={idValue}
                   defaultValue={defaultValue}
                   autoFocus={index === 0 && autoFocus}
                   initialFocus={index === 0 && initialFocus}
@@ -518,6 +521,7 @@ class Lookup extends Component {
               return (
                 <div
                   key={item.field}
+                  id={idValue}
                   className={classnames(
                     'raw-lookup-wrapper raw-lookup-wrapper-bcg',
                     {

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -403,6 +403,7 @@ class RawLookup extends Component {
       disabled,
       tabIndex,
       isOpen,
+      idValue,
     } = this.props;
     const {
       isInputEmpty,
@@ -434,48 +435,50 @@ class RawLookup extends Component {
           },
         ]}
       >
-        <div
-          className={classnames('raw-lookup-wrapper raw-lookup-wrapper-bcg', {
-            'raw-lookup-disabled': disabled,
-            'input-disabled': readonly,
-            focused: isFocused,
-          })}
-          ref={ref => (this.wrapper = ref)}
-        >
-          <div className={'input-dropdown input-block'}>
-            <div className={'input-editable' + (align ? ' text-' + align : '')}>
-              <input
-                ref={c => (this.inputSearch = c)}
-                type="text"
-                className="input-field js-input-field font-weight-semibold"
-                readOnly={readonly}
-                disabled={readonly && !disabled}
-                tabIndex={tabIndex}
-                placeholder={placeholder}
-                onChange={this.handleChange}
-                onFocus={this.handleFocus}
-              />
+        <div id={idValue || ''}>
+          <div
+            className={classnames('raw-lookup-wrapper raw-lookup-wrapper-bcg', {
+              'raw-lookup-disabled': disabled,
+              'input-disabled': readonly,
+              focused: isFocused,
+            })}
+            ref={ref => (this.wrapper = ref)}
+          >
+            <div className={'input-dropdown input-block'}>
+              <div className={'input-editable' + (align ? ' text-' + align : '')}>
+                <input
+                  ref={c => (this.inputSearch = c)}
+                  type="text"
+                  className="input-field js-input-field font-weight-semibold"
+                  readOnly={readonly}
+                  disabled={readonly && !disabled}
+                  tabIndex={tabIndex}
+                  placeholder={placeholder}
+                  onChange={this.handleChange}
+                  onFocus={this.handleFocus}
+                />
+              </div>
             </div>
           </div>
+          {isOpen &&
+            !isInputEmpty && (
+              <SelectionDropdown
+                loading={loading}
+                options={list}
+                empty="No results found"
+                forceEmpty={forceEmpty}
+                selected={selected}
+                width={
+                  this.props.forcedWidth
+                    ? this.props.forcedWidth
+                    : this.wrapper && this.wrapper.offsetWidth
+                }
+                onChange={this.handleTemporarySelection}
+                onSelect={this.handleSelect}
+                onCancel={this.handleBlur}
+              />
+            )}
         </div>
-        {isOpen &&
-          !isInputEmpty && (
-            <SelectionDropdown
-              loading={loading}
-              options={list}
-              empty="No results found"
-              forceEmpty={forceEmpty}
-              selected={selected}
-              width={
-                this.props.forcedWidth
-                  ? this.props.forcedWidth
-                  : this.wrapper && this.wrapper.offsetWidth
-              }
-              onChange={this.handleTemporarySelection}
-              onSelect={this.handleSelect}
-              onCancel={this.handleBlur}
-            />
-          )}
       </TetherComponent>
     );
   }

--- a/src/components/widget/Lookup/RawLookup.js
+++ b/src/components/widget/Lookup/RawLookup.js
@@ -445,7 +445,9 @@ class RawLookup extends Component {
             ref={ref => (this.wrapper = ref)}
           >
             <div className={'input-dropdown input-block'}>
-              <div className={'input-editable' + (align ? ' text-' + align : '')}>
+              <div
+                className={'input-editable' + (align ? ' text-' + align : '')}
+              >
                 <input
                   ref={c => (this.inputSearch = c)}
                   type="text"


### PR DESCRIPTION
Lookup command `writeIntoCompositeLookupField` will write into lookup field and select item from the loaded list (in case of lookup field) or select option from the list (in case of list fields).

Quick actions command `executeQuickAction` will use quick action's internalName parameter or fallback to processId if the first one doesn't have a value. Command can either run a quick action from the list of available actions or just select the first one.

Related to #1981 & #1978 .