### PR TITLE
Custom Number input which supports commas/dots everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-dropzone": "^4.2.9",
     "react-infinite-scroller": "^1.0.12",
     "react-interpolate-component": "~0.11.0",
+    "react-numeric-input": "^2.2.3",
     "react-onclickoutside": "~6.6.0",
     "react-popper": "^1.0.0-beta.6",
     "react-redux": "~5.0.6",

--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -456,6 +456,12 @@ input:checked + .input-slider:before {
     }
 }
 
+.react-numeric-input input {
+    padding-bottom: 4px;
+    padding-left: 0 !important;
+    border-color: white !important;
+}
+
 @media (max-width: $breakpoint){
     .input-dropdown-container .input-dropdown{
         flex-direction: column;

--- a/src/components/widget/NumericQuickInput.js
+++ b/src/components/widget/NumericQuickInput.js
@@ -1,0 +1,28 @@
+import NumericInput from 'react-numeric-input';
+
+/**
+ * Extended NumericInput component to handle numbers formatting
+ * the way we wanted.
+ * @private
+ */
+export default class NumericQuickInput extends NumericInput {
+  _format(n) {
+    let _n = this._toNumber(n);
+
+    _n += '';
+
+    if (this.props.format) {
+      return this.props.format(_n);
+    }
+
+    return _n;
+  }
+
+  _parse(x) {
+    x = String(x).replace(',', '.');
+    if (typeof this.props.parse == 'function') {
+      return parseFloat(this.props.parse(x));
+    }
+    return parseFloat(x);
+  }
+}

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -3,8 +3,8 @@ import React, { Component } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
-import NumericInput from 'react-numeric-input'
 
+import NumericInput from './NumericQuickInput';
 import { RawWidgetPropTypes, RawWidgetDefaultProps } from './PropTypes';
 import { getClassNames, generateMomentObj } from './RawWidgetHelpers';
 import { allowShortcut, disableShortcut } from '../../actions/WindowActions';
@@ -601,22 +601,17 @@ class RawWidget extends Component {
               this.getClassNames() + (isEdited ? 'input-focused ' : '')
             }
           >
-            <NumericInput
-              {...widgetProperties}
-              onChange={widgetProperties.onQuantityChange}
-              min={0}
-              step={subentity === 'quickInput' ? 0.1 : 1}
-              format={ num => {
-                console.log('num:m ', num);
-
-                return num;
-              }}
-              parse={stringValue => {
-                console.log('STRINGVAL: ', stringValue);
-                // stringValue.replace(/^\$/, "")
-                return stringValue;
-              }}
-            />
+            {subentity === 'quickInput' ? (
+              <NumericInput
+                {...widgetProperties}
+                onChange={widgetProperties.onQuantityChange}
+                min={0}
+                precision={1}
+                step={subentity === 'quickInput' ? 0.1 : 1}
+              />
+            ) : (
+              <input {...widgetProperties} type="number" min="0" step={1} />
+            )}
           </div>
         );
       case 'Number':

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -274,9 +274,12 @@ class RawWidget extends Component {
       disabled: readonly,
       onFocus: this.handleFocus,
       tabIndex: tabIndex,
-      onChange: e => handleChange && handleChange(widgetField, e.target.value),
-      onQuantityChange: valAsNum =>
-        handleChange && handleChange(widgetField, valAsNum),
+      onChange: e => {
+        if (subentity === 'quickInput') {
+          return handleChange && handleChange(widgetField, e);
+        }
+        return handleChange && handleChange(widgetField, e.target.value);
+      },
       onBlur: e => this.handleBlur(widgetField, e.target.value, id),
       onKeyDown: e =>
         this.handleKeyDown(e, widgetField, e.target.value, widgetType),
@@ -605,7 +608,6 @@ class RawWidget extends Component {
             {subentity === 'quickInput' ? (
               <NumericInput
                 {...widgetProperties}
-                onChange={widgetProperties.onQuantityChange}
                 min={0}
                 precision={1}
                 step={subentity === 'quickInput' ? 0.1 : 1}

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -275,7 +275,8 @@ class RawWidget extends Component {
       onFocus: this.handleFocus,
       tabIndex: tabIndex,
       onChange: e => handleChange && handleChange(widgetField, e.target.value),
-      onQuantityChange: valAsNum => handleChange && handleChange(widgetField, valAsNum),
+      onQuantityChange: valAsNum =>
+        handleChange && handleChange(widgetField, valAsNum),
       onBlur: e => this.handleBlur(widgetField, e.target.value, id),
       onKeyDown: e =>
         this.handleKeyDown(e, widgetField, e.target.value, widgetType),

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import NumericInput from 'react-numeric-input'
 
 import { RawWidgetPropTypes, RawWidgetDefaultProps } from './PropTypes';
 import { getClassNames, generateMomentObj } from './RawWidgetHelpers';
@@ -274,6 +275,7 @@ class RawWidget extends Component {
       onFocus: this.handleFocus,
       tabIndex: tabIndex,
       onChange: e => handleChange && handleChange(widgetField, e.target.value),
+      onQuantityChange: valAsNum => handleChange && handleChange(widgetField, valAsNum),
       onBlur: e => this.handleBlur(widgetField, e.target.value, id),
       onKeyDown: e =>
         this.handleKeyDown(e, widgetField, e.target.value, widgetType),
@@ -599,11 +601,21 @@ class RawWidget extends Component {
               this.getClassNames() + (isEdited ? 'input-focused ' : '')
             }
           >
-            <input
+            <NumericInput
               {...widgetProperties}
-              type="number"
-              min="0"
+              onChange={widgetProperties.onQuantityChange}
+              min={0}
               step={subentity === 'quickInput' ? 0.1 : 1}
+              format={ num => {
+                console.log('num:m ', num);
+
+                return num;
+              }}
+              parse={stringValue => {
+                console.log('STRINGVAL: ', stringValue);
+                // stringValue.replace(/^\$/, "")
+                return stringValue;
+              }}
             />
           </div>
         );


### PR DESCRIPTION
Because of browser/OS differences and how number formatting is supported we can't guarantee, that dot and comma number separators are supported everywhere with the built-in number field. So I created a custom one that does the job.

Related to #2005 