### PR TITLE
Fix DocumentNote cypress test

### DIFF
--- a/cypress/integration/product_set_documentnote.js
+++ b/cypress/integration/product_set_documentnote.js
@@ -6,6 +6,8 @@ describe('Product DocumentNote test', function() {
     it('open the product window', function() {
         cy.visit('window/140/2005577');
 
+        cy.waitForHeader('Product Management');
+
         cy.openAdvancedEdit();
         cy.writeIntoTextField('DocumentNote', 'blah-blah-blah');
     });

--- a/cypress/integration/product_set_documentnote.js
+++ b/cypress/integration/product_set_documentnote.js
@@ -1,13 +1,11 @@
 describe('Product DocumentNote test', function() {
     before(function() {
-        cy.loginByForm();
+      cy.loginByForm();
     });
 
     it('open the product window', function() {
-        cy.visit('window/140/2005577');
-
-        cy.waitForHeader('Product Management');
-
+      cy.visit('window/140/2005577');
+        cy.waitForHeader();
         cy.openAdvancedEdit();
         cy.writeIntoTextField('DocumentNote', 'blah-blah-blah');
     });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -236,6 +236,19 @@ Cypress.Commands.add('selectTab', (tabName) => {
   });
 });
 
+/*
+ * This command allows waiting for the breadcrumb in the header to be visible, which
+ * helps make the tests less flaky as even though the page fires load event, some
+ * requests may still be pending/running.
+ *
+ * Command accepts two params:
+ * - pageName : if we explicitly want to define what to wait for
+ * - breadcrumbNr : if we want to select breadcrumb value from the redux store at
+ *                  the given index
+ * In case pageName is not defined, command will fall back to broadcrembNr and either
+ * use the provided value or the value at index 0.
+ *
+ */
 Cypress.Commands.add('waitForHeader', (pageName, breadcrumbNr) => {
   describe('Wait for page name visible in the header', function() {
     if (pageName) {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -225,7 +225,9 @@ Cypress.Commands.add('processDocument', (action, expectedStatus) => {
 
 Cypress.Commands.add('openAdvancedEdit', () => {
   describe('Open the advanced edit overlay via ALT+E shortcut', function() {
-    cy.get('body').type('{alt}E')
+    cy.get('body').type('{alt}N');
+    cy.get('body').type('{alt}E');
+    cy.get('.panel-modal').should('exist');
   })
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -225,7 +225,6 @@ Cypress.Commands.add('processDocument', (action, expectedStatus) => {
 
 Cypress.Commands.add('openAdvancedEdit', () => {
   describe('Open the advanced edit overlay via ALT+E shortcut', function() {
-    cy.get('body').type('{alt}N');
     cy.get('body').type('{alt}E');
     cy.get('.panel-modal').should('exist');
   })
@@ -234,6 +233,12 @@ Cypress.Commands.add('openAdvancedEdit', () => {
 Cypress.Commands.add('selectTab', (tabName) => {
   describe('Select and activate the tab with a certain name', function() {
     return cy.get(`#tab_${tabName}`).click()
+  });
+});
+
+Cypress.Commands.add('waitForHeader', (pageName) => {
+  describe('Wait for page name visible in the header', function() {
+    cy.get('.header-item').should('contain', pageName);
   });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -238,7 +238,23 @@ Cypress.Commands.add('selectTab', (tabName) => {
 
 Cypress.Commands.add('waitForHeader', (pageName) => {
   describe('Wait for page name visible in the header', function() {
-    cy.get('.header-item').should('contain', pageName);
+    if (pageName) {
+      cy.get('.header-breadcrumb')
+        .find('.header-item-container')
+        .should('not.have.length', 1)
+        .get('.header-item').should('contain', pageName);
+    } else {
+      cy.get('.header-breadcrumb')
+        .find('.header-item-container')
+        .should('not.have.length', 1)
+        .window().its('store').invoke('getState').its('menuHandler.breadcrumb')
+        .should('not.have.length', 0)
+        .window().its('store').invoke('getState')
+        .its('menuHandler.breadcrumb')
+        .then((breadcrumbs) => {
+          cy.get('.header-item').should('contain', breadcrumbs[0].caption);
+        });
+    }
   });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -236,7 +236,7 @@ Cypress.Commands.add('selectTab', (tabName) => {
   });
 });
 
-Cypress.Commands.add('waitForHeader', (pageName) => {
+Cypress.Commands.add('waitForHeader', (pageName, breadcrumbNr) => {
   describe('Wait for page name visible in the header', function() {
     if (pageName) {
       cy.get('.header-breadcrumb')
@@ -244,6 +244,8 @@ Cypress.Commands.add('waitForHeader', (pageName) => {
         .should('not.have.length', 1)
         .get('.header-item').should('contain', pageName);
     } else {
+      const breadcrumbNumber = breadcrumbNr || 0;
+
       cy.get('.header-breadcrumb')
         .find('.header-item-container')
         .should('not.have.length', 1)
@@ -252,7 +254,7 @@ Cypress.Commands.add('waitForHeader', (pageName) => {
         .window().its('store').invoke('getState')
         .its('menuHandler.breadcrumb')
         .then((breadcrumbs) => {
-          cy.get('.header-item').should('contain', breadcrumbs[0].caption);
+          cy.get('.header-item').should('contain', breadcrumbs[breadcrumbNumber].caption);
         });
     }
   });

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -31,6 +31,10 @@ const store = configureStore(browserHistory);
 const history = syncHistoryWithStore(browserHistory, store);
 const APP_PLUGINS = PLUGINS ? PLUGINS : [];
 
+if (window.Cypress) {
+  window.store = store;
+}
+
 export default class App extends Component {
   constructor(props) {
     super(props);


### PR DESCRIPTION
I'm pretty sure this test never worked. And if we're at it, it doesn't really test anything now. But fixed the command to open advanced edit and now it passes.

Related to #1997 