### PR TITLE
Fix patching fields in tables with keyboard keys

### DIFF
--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -1,0 +1,190 @@
+import React from 'react';
+import { mount, shallow, render } from 'enzyme';
+
+import { RawWidget } from '../../../components/widget/RawWidget';
+import fixtures from '../../../../test_setup/fixtures/raw_widget.json';
+
+const createDummyProps = function(props) {
+  return {
+    dispatch: jest.fn(),
+    modalVisible: false,
+    entity: "window",
+    dataId: "1001282",
+    ...props,
+  };
+};
+
+describe('RawWidget component', () => {
+  describe('generic tests using LongText widget:', () => {
+    it('renders widget without errors', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1 }],
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('form-group row');
+      expect(html).toContain('input-block');
+      expect(wrapper.find('textarea').length).toBe(1);
+      expect(html).toContain(fixtures.longText.data1.value)
+      expect(html).toContain(fixtures.longText.layout1.description)
+    });
+
+    it('renders nothing when widget is not displayed', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1, displayed: false }],
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toEqual(null);
+    });
+
+    it('calls `handlePatch` on `{enter}/{tab}` keydown', () => {
+      const handlePatchSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1 }],
+          handlePatch: handlePatchSpy,
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+
+      wrapper.find('textarea').simulate(
+        'keyDown',
+        {
+          key: 'Enter',
+          target: { value: fixtures.longText.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+
+      wrapper.find('textarea').simulate(
+        'keyDown',
+        {
+          key: 'Tab',
+          target: { value: fixtures.longText.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+    });
+
+    it('doesn\'t call `handlePatch` on `{shift}{enter}` keydown', () => {
+      const handlePatchSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1 }],
+          handlePatch: handlePatchSpy,
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+
+      wrapper.find('textarea').simulate(
+        'keyDown',
+        {
+          key: 'Enter',
+          shiftKey: true,
+          target: { value: fixtures.longText.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).not.toHaveBeenCalled();
+    });
+
+    it('doesn\'t call `handlePatch` on `{shift}{enter}` keydown', () => {
+      const handlePatchSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1 }],
+          handlePatch: handlePatchSpy,
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+
+      wrapper.find('textarea').simulate(
+        'keyDown',
+        {
+          key: 'Enter',
+          shiftKey: true,
+          target: { value: fixtures.longText.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).not.toHaveBeenCalled();
+    });
+
+    it('correct handlers/prop functions are called on focus/blur', () => {
+      const patchSpy = jest.fn();
+      const blurSpy = jest.fn();
+      const focusSpy = jest.fn();
+      const clickOutsideSpy = jest.fn();
+      const listenOnKeysTrueSpy = jest.fn();
+      const listenOnKeysFalseSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.longText.layout1,
+          widgetData: [{ ...fixtures.longText.data1 }],
+          handlePatch: patchSpy,
+          handleBlur: blurSpy,
+          handleFocus: focusSpy,
+          listenOnKeysFalse: listenOnKeysFalseSpy,
+          listenOnKeysTrue: listenOnKeysTrueSpy,
+          enableOnClickOutside: clickOutsideSpy,
+        },
+      );
+
+      const wrapper = mount(<RawWidget {...props} />);
+      const instance = wrapper.instance();
+      const handleFocusSpy = jest.spyOn(instance, 'handleFocus');
+      const handleBlurSpy = jest.spyOn(instance, 'handleBlur');
+
+      wrapper.instance().forceUpdate();
+      wrapper.update();
+
+      wrapper.find('textarea')
+        .prop('onFocus')({ target: { value: fixtures.longText.data1.value } });
+
+      expect(focusSpy).toHaveBeenCalled();
+      expect(handleFocusSpy).toHaveBeenCalled();
+      expect(listenOnKeysFalseSpy).toHaveBeenCalled();
+
+      wrapper.find('textarea')
+        .prop('onBlur')(
+          { target: { value: fixtures.longText.data1.value } }
+        );
+
+      expect(patchSpy).toHaveBeenCalled();
+      expect(blurSpy).toHaveBeenCalled();
+      expect(handleBlurSpy).toHaveBeenCalled();
+      expect(clickOutsideSpy).toHaveBeenCalled();
+      expect(listenOnKeysTrueSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -22,7 +22,7 @@ import Link from './Link';
 import List from './List/List';
 import Lookup from './Lookup/Lookup';
 
-class RawWidget extends Component {
+export class RawWidget extends Component {
   constructor(props) {
     super(props);
 
@@ -120,7 +120,7 @@ class RawWidget extends Component {
       if (e.key === 'Enter') {
         e.preventDefault();
       }
-      this.handlePatch(property, value);
+      return this.handlePatch(property, value);
     }
   };
 
@@ -253,6 +253,7 @@ class RawWidget extends Component {
       dateFormat,
       initialFocus,
     } = this.props;
+
     let widgetValue = data != null ? data : widgetData[0].value;
     const { isEdited } = this.state;
 

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -115,8 +115,11 @@ class RawWidget extends Component {
     );
   };
 
-  handleKeyDown = (e, property, value, widgetType) => {
-    if ((e.key === 'Enter' || e.key === 'Tab') && widgetType !== 'LongText') {
+  handleKeyDown = (e, property, value) => {
+    if ((e.key === 'Enter' || e.key === 'Tab') && !e.shiftKey) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+      }
       this.handlePatch(property, value);
     }
   };
@@ -284,8 +287,7 @@ class RawWidget extends Component {
         return handleChange && handleChange(widgetField, e.target.value);
       },
       onBlur: e => this.handleBlur(widgetField, e.target.value, id),
-      onKeyDown: e =>
-        this.handleKeyDown(e, widgetField, e.target.value, widgetType),
+      onKeyDown: e => this.handleKeyDown(e, widgetField, e.target.value),
       title: widgetValue,
     };
 

--- a/test_setup/fixtures/raw_widget.json
+++ b/test_setup/fixtures/raw_widget.json
@@ -1,0 +1,38 @@
+{
+  "longText": {
+    "data1": {
+      "displayed": true,
+      "field": "ProductDescription",
+      "mandatory": false,
+      "readonly": false,
+      "validStatus": {
+        "valid": true,
+        "initialValue": true,
+        "fieldName": "ProductDescription"
+      },
+      "fieldName": "ProductDescription",
+      "initialValue": true,
+      "valid": true,
+      "value": "Test 134",
+      "viewEditorRenderMode": "always",
+      "widgetType": "LongText"
+    },
+    "layout1": {
+      "caption": "Product Description",
+      "description": "Product Description",
+      "fields": [
+        {
+          "field": "ProductDescription",
+          "emptyText": "none"
+        }
+      ],
+      "gridAlign": "left",
+      "multilineText": true,
+      "multilineTextLines": 3,
+      "size": "L",
+      "sortable": true,
+      "viewEditorRenderMode": "never",
+      "widgetType": "LongText"
+    }
+  }
+}


### PR DESCRIPTION
This was not consistent both from the UX perspective, as well as how we handled this in the code. Long textfields should be handled the same way as other fields to simplify maintenance. I've also changed how we handle `Enter/Tab` keys for textareas. The natural way is to add new line when `Shift+Enter` is pressed, and to submit change with `Enter` alone.

Related to #2066 #2070 