### PR TITLE
extract the edit-location code into a command

### DIFF
--- a/cypress/integration/purchase_create_vendor_spec.js
+++ b/cypress/integration/purchase_create_vendor_spec.js
@@ -24,35 +24,17 @@ describe('purchase order Test', function() {
     // TODO: Use proper tab name when rolled out - Kuba
     cy.selectTab('C_BPartner_Location');
     cy.pressAddNewButton();
-    cy.writeIntoStringField('Name', 'Address');
-
-    cy.server()
-    cy.route('POST', '/rest/api/address').as('postAddress')
+    cy.writeIntoStringField('Name', 'Address1');
     
-    // TODO: extract into a command
-    // Kuba: I'm not sure if this wouldn't be too specific for this use case.
-    cy.get('.form-field-C_Location_ID').find('button').click();
-
-    cy.wait('@postAddress').then(xhr => {
-      const requestId = xhr.response.body.id;
-
-      Cypress.emit('emit:addressPatchResolved', requestId);
+    cy.editAddress('C_Location_ID', function a() {
+        cy.writeIntoStringField('City', 'Cologne')
+        cy.writeIntoLookupField('C_Country_ID', 'Deu', 'Deutschland');
+        // cy.get('.panel-modal-header').click();
     });
-
-    cy.on('emit:addressPatchResolved', (requestId) => {
-      cy.route('POST', `/rest/api/address/${requestId}/complete`).as('completeAddress');
-      cy.writeIntoStringField('City', 'Cologne')
-        .writeIntoLookupField('C_Country_ID', 'Deu', 'Deutschland');
-      cy.get('.panel-modal-header').click();
-
-      cy.wait('@completeAddress');
-
-      cy.get('.form-field-Address')
+    cy.get('.form-field-Address')
         .should('contain', 'Cologne');
+    cy.pressDoneButton();  
 
-      cy.pressDoneButton();
-
-      // TODO: Use proper tab name when rolled out - Kuba
       cy.selectTab('AD_User');
       cy.pressAddNewButton();
       cy.writeIntoStringField('Firstname', 'Default');
@@ -68,6 +50,5 @@ describe('purchase order Test', function() {
 
       cy.get('table tbody tr')
         .should('have.length', 2);
-    });
   });
 });

--- a/cypress/integration/serialletter/serialletter.js
+++ b/cypress/integration/serialletter/serialletter.js
@@ -1,0 +1,67 @@
+/// <reference types="Cypress" />
+
+before(function() {
+    // login before each test
+    cy.loginByForm();
+});
+
+it('Serial letter', function() {
+    const timestamp = new Date().getTime(); // used in the document names, for ordering
+    const printFormatName = `${timestamp} Serial letter printformat`;
+    const marketingPlatformName = `${timestamp} Serial letter marketing platform`;
+    const boilerPlateName = `${timestamp}_Serial_letter_text_snippet`;
+    
+    const marketingCampaignName = `${timestamp} Serial letter marketing campaign`;
+    const marketingContactName = `${timestamp} Serial letter marketing contact`;
+
+//    describe('Create print format and doc outbound log', function() {
+            cy.visit('/window/240/NEW');
+            cy.writeIntoStringField('Name', printFormatName);
+            cy.writeIntoLookupField('AD_Table_ID', 'Letter', 'Letter');
+            cy.writeIntoLookupField('JasperProcess_ID', 'Serial Letter', 'Serial Letter');
+
+            cy.visit('/window/540173/NEW');
+            cy.writeIntoLookupField('AD_Table_ID', 'Letter', 'Letter');
+            cy.writeIntoLookupField('AD_PrintFormat_ID', printFormatName, printFormatName);
+            cy.clickOnCheckBox('IsCreatePrintJob');
+            cy.wait(500);
+//    });
+
+//    describe('create Marketing platform', function() {
+        cy.visit('/window/540437/NEW');
+        cy.writeIntoStringField('Name', marketingPlatformName);
+        cy.clickOnCheckBox('IsRequiredLocation');
+        cy.wait(500);
+//    })
+
+    // create boiler plate (text-snippet)
+    cy.visit('/window/504410/NEW');
+    cy.writeIntoStringField('Name', boilerPlateName);
+    cy.writeIntoStringField('Subject', 'Subject');
+    cy.writeIntoTextField('TextSnippet', 'TextSnippet');
+    cy.selectTab('AD_BoilerPlate_Ref'); // need to click somewhere outside of the text field
+
+    // create contact person
+    cy.visit('/window/540435/NEW');
+    cy.writeIntoStringField('Name', marketingContactName);
+    cy.writeIntoLookupField('MKTG_Platform_ID', marketingPlatformName, marketingPlatformName);
+    cy.editAddress('C_Location_ID', function () {
+        cy.writeIntoStringField('City', 'Cologne')
+        cy.writeIntoLookupField('C_Country_ID', 'Deu', 'Deutschland');
+    });
+    
+    // create marketing campaign
+    cy.visit('/window/540434/NEW');
+    cy.writeIntoStringField('Name', marketingCampaignName);
+    cy.writeIntoLookupField('MKTG_Platform_ID', marketingPlatformName, marketingPlatformName);
+    cy.writeIntoLookupField('AD_BoilerPlate_ID', boilerPlateName, boilerPlateName);
+
+    // add contact person to campaign
+    cy.selectTab('MKTG_Campaign_ContactPerson');
+    cy.pressAddNewButton();
+    cy.writeIntoLookupField('MKTG_ContactPerson_ID', marketingContactName, marketingContactName);
+    cy.pressDoneButton();
+
+    // needs https://github.com/metasfresh/metasfresh-webui-frontend/issues/1978#issuecomment-445274540
+    // cy.executeProcess('C_Letter_CreateFrom_MKTG_ContactPerson');
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -298,6 +298,32 @@ Cypress.Commands.add('selectSingleTabRow', () => {
   });
 });
 
+Cypress.Commands.add('editAddress', (fieldName, addressFunction) => {
+  describe(`Select ${fieldName}'s address-button and invoke the given function`, function() {
+   
+    cy.server()
+    cy.route('POST', '/rest/api/address').as('postAddress')
+
+    cy.get(`.form-field-${fieldName}`).find('button').click();
+
+    cy.wait('@postAddress').then(xhr => {
+      const requestId = xhr.response.body.id;
+
+      Cypress.emit('emit:addressPatchResolved', requestId);
+    });
+
+    cy.on('emit:addressPatchResolved', (requestId) => {
+
+      cy.route('POST', `/rest/api/address/${requestId}/complete`).as('completeAddress');
+
+      addressFunction();
+      cy.get(`.form-field-C_Location_ID`).click();
+      cy.wait('@completeAddress');
+    });
+
+  });
+});
+
 // This command runs a quick actions. If second parameter is truthy, the default action
 // will be executed.
 Cypress.Commands.add('executeQuickAction', (actionName, active) => {


### PR DESCRIPTION
Here i basically extracted the code you provided in https://github.com/metasfresh/metasfresh-webui-frontend/issues/2080 into `commands.js`
Note that you argued against doing that in https://github.com/metasfresh/metasfresh-webui-frontend/pull/2089/files#r238242135 .
But..the spec looks a lot cleaner..and I could reuse it in a serial letter test which is also part of this PR.
so wdyt? doesn't make sense?
