### PR TITLE
Fix camera on latest Chrome

### DIFF
--- a/src/components/widget/Image.js
+++ b/src/components/widget/Image.js
@@ -150,7 +150,7 @@ class Image extends Component {
             },
           })
           .then(stream => {
-            this.camera.src = window.URL.createObjectURL(stream);
+            this.camera.srcObject = stream;
             this.camera.onloadedmetadata = () => {
               this.camera.play();
             };


### PR DESCRIPTION
Turns out they removed some method deprecated since 2013. Here's a quick fix but I have to look into this code to be sure there's no other surprises there.

Related #2124