### PR TITLE
Fix height of tables with little data

### DIFF
--- a/src/assets/css/header.css
+++ b/src/assets/css/header.css
@@ -2,7 +2,7 @@
 
 
 .header-sticky-distance{
-    margin-top: 55px;
+    padding-top: 55px;
 }
 
 .header {
@@ -83,7 +83,7 @@
         padding:4px 0;
     }
     .header-sticky-distance {
-        margin-top: 130px;
+        padding-top: 130px;
     }
 }
 

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -828,10 +828,13 @@ body {
 html, body{
     padding: 0;
     margin: 0;
-}
-html{
     height: 100%;
 }
+
+html {
+    overflow: scroll;
+}
+
 body{
     min-height: 100%;
     top: 0;


### PR DESCRIPTION
Changed the main elements and header styling to fix tables with small amount of rows not taking 100% of the window. Checked with lists, modals and login screen. Everything seems to be working fine.

Related to #2148 