### PR TITLE
General adjustments for widgets

### DIFF
--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -169,7 +169,7 @@ describe('RawWidget component', () => {
       wrapper.update();
 
       wrapper.find('textarea')
-        .prop('onFocus')({ target: { value: fixtures.longText.data1.value } });
+        .prop('onFocus')({ target: { value: '' } });
 
       expect(focusSpy).toHaveBeenCalled();
       expect(handleFocusSpy).toHaveBeenCalled();

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -284,7 +284,6 @@ export class RawList extends PureComponent {
       lookupList,
       isToggled,
       isFocused,
-      onFocus,
       clearable,
     } = this.props;
 

--- a/src/components/widget/List/RawList.js
+++ b/src/components/widget/List/RawList.js
@@ -331,7 +331,6 @@ export class RawList extends PureComponent {
             'input-mandatory': !lookupList && mandatory && !selected,
           })}
           tabIndex={tabIndex}
-          _onFocus={readonly ? null : onFocus}
           onFocus={readonly ? null : this.focusDropdown}
           onClick={readonly ? null : this.handleClick}
           onKeyDown={this.handleKeyDown}

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -116,11 +116,9 @@ export class RawWidget extends Component {
     );
   };
 
-  handleKeyDown = (e, property, value, widgetType) => {
+  handleKeyDown = (e, property, value) => {
     if ((e.key === 'Enter' || e.key === 'Tab') && !e.shiftKey) {
-      if (e.key === 'Enter' && widgetType.search(/text/i) > -1) {
-        e.preventDefault();
-      }
+      e.preventDefault();
       return this.handlePatch(property, value);
     }
   };

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -77,15 +77,17 @@ export class RawWidget extends Component {
 
     dispatch(disableShortcut());
 
-    setTimeout(() => {
-      this.setState({
+    listenOnKeysFalse && listenOnKeysFalse();
+
+    this.setState(
+      {
         isEdited: true,
         cachedValue: el.value,
-      });
-    }, 0);
-
-    listenOnKeysFalse && listenOnKeysFalse();
-    handleFocus && handleFocus();
+      },
+      () => {
+        handleFocus && handleFocus();
+      }
+    );
   };
 
   handleBlur = (widgetField, value, id) => {
@@ -99,7 +101,6 @@ export class RawWidget extends Component {
     this.setState(
       {
         isEdited: false,
-        cachedValue: undefined,
       },
       () => {
         enableOnClickOutside && enableOnClickOutside();
@@ -182,9 +183,9 @@ export class RawWidget extends Component {
 
     let allowPatching =
       (isValue &&
-        (JSON.stringify(fieldData.value) !== JSON.stringify(value) ||
-          JSON.stringify(fieldData.valueTo) !== JSON.stringify(valueTo))) ||
-      JSON.stringify(cachedValue) !== JSON.stringify(value);
+        (JSON.stringify(fieldData.value) != JSON.stringify(value) ||
+          JSON.stringify(fieldData.valueTo) != JSON.stringify(valueTo))) ||
+      JSON.stringify(cachedValue) != JSON.stringify(value);
 
     return allowPatching;
   };


### PR DESCRIPTION
Related to #2214

As far as I can tell this is only reproducible in cypress tests. Two things I've changed are:
* to NOT reset widgets when field is blurred as it caused multiple unnecessary requests to the server even if value haven't changed
* prevent default action on all inputs

So when testing we should just check if nothing looks out of place and behaves incorrectly when editing/updating fields.