### PR TITLE
Fix how tab key works for inputs

### DIFF
--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -113,33 +113,6 @@ describe('RawWidget component', () => {
       expect(handlePatchSpy).not.toHaveBeenCalled();
     });
 
-    it('doesn\'t call `handlePatch` on `{shift}{enter}` keydown', () => {
-      const handlePatchSpy = jest.fn();
-      const props = createDummyProps(
-        {
-          ...fixtures.longText.layout1,
-          widgetData: [{ ...fixtures.longText.data1 }],
-          handlePatch: handlePatchSpy,
-        },
-      );
-
-      const wrapper = shallow(<RawWidget {...props} />);
-      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
-
-      wrapper.find('textarea').simulate(
-        'keyDown',
-        {
-          key: 'Enter',
-          shiftKey: true,
-          target: { value: fixtures.longText.data1.value },
-          preventDefault: jest.fn(),
-        },
-      );
-
-      expect(spy).toHaveBeenCalled();
-      expect(handlePatchSpy).not.toHaveBeenCalled();
-    });
-
     it('correct handlers/prop functions are called on focus/blur', () => {
       jest.useFakeTimers();
 
@@ -188,6 +161,204 @@ describe('RawWidget component', () => {
       expect(handleBlurSpy).toHaveBeenCalled();
       expect(clickOutsideSpy).toHaveBeenCalled();
       expect(listenOnKeysTrueSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('generic tests using Text widget:', () => {
+    it('renders widget without errors', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.text.layout1,
+          widgetData: [{ ...fixtures.text.data1 }],
+        },
+      );
+ 
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('form-group row');
+      expect(html).toContain('input-block');
+      expect(wrapper.find('input').length).toBe(1);
+      expect(html).toContain(fixtures.text.data1.value)
+      expect(html).toContain(fixtures.text.layout1.description)
+    });
+
+    it('renders nothing when widget is not displayed', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.text.layout1,
+          widgetData: [{ ...fixtures.text.data1, displayed: false }],
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toEqual(null);
+    });
+
+    it('calls `handlePatch` on `{enter}/{tab}` keydown', () => {
+      const handlePatchSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.text.layout1,
+          widgetData: [{ ...fixtures.text.data1 }],
+          handlePatch: handlePatchSpy,
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+
+      wrapper.find('input').simulate(
+        'keyDown',
+        {
+          key: 'Enter',
+          target: { value: fixtures.text.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+
+      wrapper.find('input').simulate(
+        'keyDown',
+        {
+          key: 'Tab',
+          target: { value: fixtures.text.data1.value },
+          preventDefault: jest.fn(),
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+    });
+
+    it('correct handlers/prop functions are called on focus/blur', () => {
+      jest.useFakeTimers();
+
+      const patchSpy = jest.fn();
+      const blurSpy = jest.fn();
+      const focusSpy = jest.fn();
+      const clickOutsideSpy = jest.fn();
+      const listenOnKeysTrueSpy = jest.fn();
+      const listenOnKeysFalseSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.text.layout1,
+          widgetData: [{ ...fixtures.text.data1 }],
+          handlePatch: patchSpy,
+          handleBlur: blurSpy,
+          handleFocus: focusSpy,
+          listenOnKeysFalse: listenOnKeysFalseSpy,
+          listenOnKeysTrue: listenOnKeysTrueSpy,
+          enableOnClickOutside: clickOutsideSpy,
+        },
+      );
+
+      const wrapper = mount(<RawWidget {...props} />);
+      const instance = wrapper.instance();
+      const handleFocusSpy = jest.spyOn(instance, 'handleFocus');
+      const handleBlurSpy = jest.spyOn(instance, 'handleBlur');
+
+      wrapper.instance().forceUpdate();
+      wrapper.update();
+
+      wrapper.find('input')
+        .prop('onFocus')({ target: { value: '' } });
+      jest.runAllTimers();
+
+      expect(handleFocusSpy).toHaveBeenCalled();
+      expect(focusSpy).toHaveBeenCalled();
+      expect(listenOnKeysFalseSpy).toHaveBeenCalled();
+
+      wrapper.find('input')
+        .prop('onBlur')(
+          { target: { value: fixtures.text.data1.value } }
+        );
+
+      expect(patchSpy).toHaveBeenCalled();
+      expect(blurSpy).toHaveBeenCalled();
+      expect(handleBlurSpy).toHaveBeenCalled();
+      expect(clickOutsideSpy).toHaveBeenCalled();
+      expect(listenOnKeysTrueSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('generic tests using Integer widget:', () => {
+    it('renders widget without errors', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.integer.layout1,
+          widgetData: [{ ...fixtures.integer.data1 }],
+        },
+      );
+ 
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('form-group row');
+      expect(html).toContain('input-block');
+      expect(wrapper.find('input').length).toBe(1);
+      expect(html).toContain(fixtures.integer.data1.value)
+      expect(html).toContain(fixtures.integer.layout1.description)
+    });
+
+    it('renders nothing when widget is not displayed', () => {
+      const props = createDummyProps(
+        {
+          ...fixtures.integer.layout1,
+          widgetData: [{ ...fixtures.integer.data1, displayed: false }],
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const html = wrapper.html();
+
+      expect(html).toEqual(null);
+    });
+
+    it('calls `handlePatch` on `{enter}/{tab}` keydown', () => {
+      const handlePatchSpy = jest.fn();
+      const preventDefaultSpy = jest.fn();
+      const props = createDummyProps(
+        {
+          ...fixtures.integer.layout1,
+          widgetData: [{ ...fixtures.integer.data1 }],
+          handlePatch: handlePatchSpy,
+        },
+      );
+
+      const wrapper = shallow(<RawWidget {...props} />);
+      const spy = jest.spyOn(wrapper.instance(), 'handleKeyDown');
+
+      wrapper.find('input').simulate(
+        'keyDown',
+        {
+          key: 'Enter',
+          target: { value: fixtures.integer.data1.value },
+          preventDefault: preventDefaultSpy,
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      preventDefaultSpy.mockClear();
+
+      wrapper.find('input').simulate(
+        'keyDown',
+        {
+          key: 'Tab',
+          target: { value: fixtures.integer.data1.value },
+          preventDefault: preventDefaultSpy,
+        },
+      );
+
+      expect(spy).toHaveBeenCalled();
+      expect(handlePatchSpy).toHaveBeenCalled();
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -121,10 +121,9 @@ export class RawWidget extends Component {
     const { lastFormField } = this.props;
 
     if ((e.key === 'Enter' || e.key === 'Tab') && !e.shiftKey) {
-      if (!lastFormField) {
+      if (e.key === 'Enter' && !lastFormField) {
         e.preventDefault();
       }
-
       return this.handlePatch(property, value);
     }
   };

--- a/test_setup/fixtures/raw_widget.json
+++ b/test_setup/fixtures/raw_widget.json
@@ -34,5 +34,70 @@
       "viewEditorRenderMode": "never",
       "widgetType": "LongText"
     }
+  },
+  "text": {
+    "data1": {
+      "displayed": true,
+      "field": "Name",
+      "mandatory": true,
+      "readonly": false,
+      "validStatus": {
+        "valid": true,
+        "initialValue": true,
+        "fieldName": "Name"
+      },
+      "fieldName": "Name",
+      "initialValue": true,
+      "valid": true,
+      "value": "Apricotest",
+      "viewEditorRenderMode": "always",
+      "widgetType": "Text"
+    },
+    "layout1": {
+      "caption": "Name",
+      "description": "",
+      "fields": [
+        {
+          "field": "Name",
+          "emptyText": "none"
+        }
+      ],
+      "size": "L",
+      "viewEditorRenderMode": "never",
+      "widgetType": "Text"
+    }
+  },
+  "integer": {
+    "data1": {
+      "displayed": true,
+      "field": "SeqNo",
+      "mandatory": true,
+      "readonly": false,
+      "validStatus": {
+        "valid": true,
+        "initialValue": true,
+        "fieldName": "SeqNo"
+      },
+      "fieldName": "SeqNo",
+      "initialValue": true,
+      "valid": true,
+      "value": "21",
+      "viewEditorRenderMode": "always",
+      "widgetType": "Integer"
+    },
+    "layout1": {
+      "caption": "Reihenfolge",
+      "description": "Zur Bestimmung der Reihenfolge der Einträge; die kleinste Zahl kommt zuerst",
+      "fields": [
+        {
+          "field": "SeqNo",
+          "emptyText": "none"
+        }
+      ],
+      "emptyText": "none",
+      "field": "SeqNo",
+      "viewEditorRenderMode": "never",
+      "widgetType": "Integer"
+    }
   }
 }


### PR DESCRIPTION
Related to #2244 

Unit tests included, some of this is also covered by e2e tests.

Note to IT:
To align with the latest changes:
- `{enter}` in last quickinput field should submit the form
- `{enter}` in general sends PATCH request and prevents default action for the input
- `{enter}+{shift}` in text fields will go to next line
- `{tab}` will patch field, and do the default browser action. Does not prevent default input action.