### PR TITLE
Make TableQuickInput widgets smarter

### DIFF
--- a/src/components/widget/PropTypes.js
+++ b/src/components/widget/PropTypes.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 export const RawWidgetPropTypes = {
   dispatch: PropTypes.func.isRequired,
+  inProgress: PropTypes.bool,
   autoFocus: PropTypes.bool,
   textSelected: PropTypes.bool,
   listenOnKeys: PropTypes.bool,

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -128,12 +128,12 @@ export class RawWidget extends Component {
   // Datepicker is checking the cached value in datepicker component itself
   // and send a patch request only if date is changed
   handlePatch = (property, value, id, valueTo, isForce) => {
-    const { handlePatch } = this.props;
+    const { handlePatch, inProgress } = this.props;
     const willPatch = this.willPatch(property, value, valueTo);
 
     // Do patch only when value is not equal state
     // or cache is set and it is not equal value
-    if ((isForce || willPatch) && handlePatch) {
+    if ((isForce || willPatch) && handlePatch && !inProgress) {
       this.setState({
         cachedValue: value,
         clearedFieldWarning: false,


### PR DESCRIPTION
Now when there's a submit to the server, fields won't patch by themselves.

I've run a bunch of cypress tests and everything works fine, so we should be good to go.

Related to #2325 