### PR TITLE
Show new lines in modal description

### DIFF
--- a/src/assets/css/panel.css
+++ b/src/assets/css/panel.css
@@ -199,6 +199,7 @@
 .modal-top-description {
     font-size: 14px;
     padding-top: 10px;
+    white-space: pre-wrap;
 }
 
 .panel-inline>* {


### PR DESCRIPTION
Turned out it can be simply done with a `white-space` css rule. 

Related to #2350 