### PR TITLE
Fix dates formatting from filters

### DIFF
--- a/src/components/filters/FiltersItem.js
+++ b/src/components/filters/FiltersItem.js
@@ -12,7 +12,7 @@ import ModalContextShortcuts from '../keyshortcuts/ModalContextShortcuts';
 import Tooltips from '../tooltips/Tooltips.js';
 import RawWidget from '../widget/RawWidget';
 import { openFilterBox, closeFilterBox } from '../../actions/WindowActions';
-import { parseDateWithCurrenTimezone } from '../../utils/documentListHelper';
+import { parseDateWithCurrentTimezone } from '../../utils/documentListHelper';
 import { DATE_FIELDS } from '../../constants/Constants';
 class FiltersItem extends Component {
   constructor(props) {
@@ -157,7 +157,7 @@ class FiltersItem extends Component {
 
   parseDateToReadable = (widgetType, value) => {
     if (DATE_FIELDS.indexOf(widgetType) > -1) {
-      return parseDateWithCurrenTimezone(value);
+      return parseDateWithCurrentTimezone(value, widgetType);
     }
     return value;
   };

--- a/src/components/filters/InlineFilterItem.js
+++ b/src/components/filters/InlineFilterItem.js
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 
 import RawWidget from '../widget/RawWidget';
-import { parseDateWithCurrenTimezone } from '../../utils/documentListHelper';
+import { parseDateWithCurrentTimezone } from '../../utils/documentListHelper';
 import { DATE_FIELDS } from '../../constants/Constants';
 
 class InlineFilterItem extends Component {
@@ -75,7 +75,7 @@ class InlineFilterItem extends Component {
 
   parseDateToReadable = (widgetType, value) => {
     if (DATE_FIELDS.indexOf(widgetType) > -1) {
-      return parseDateWithCurrenTimezone(value);
+      return parseDateWithCurrentTimezone(value);
     }
     return value;
   };

--- a/src/components/widget/Checkbox.js
+++ b/src/components/widget/Checkbox.js
@@ -72,7 +72,7 @@ Checkbox.propTypes = {
   filterWidget: PropTypes.bool,
   handlePatch: PropTypes.func,
   widgetField: PropTypes.string,
-  id: PropTypes.string,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default Checkbox;

--- a/src/components/widget/RawWidgetHelpers.js
+++ b/src/components/widget/RawWidgetHelpers.js
@@ -1,5 +1,35 @@
-import Moment from 'moment';
+import Moment from 'moment-timezone';
 
+import {
+  DATE_FORMAT,
+  TIME_FORMAT,
+  DATE_TIMEZONE_FORMAT,
+} from '../../constants/Constants';
+
+/*
+ * Helper function returning proper date field formatting depending on the
+ * given widget type
+ *
+ * @param {string} widgetType
+ * @return {string} format
+ */
+export function getFormatForDateField(widgetType) {
+  let fmt = DATE_TIMEZONE_FORMAT;
+  if (widgetType === `Date`) {
+    fmt = DATE_FORMAT;
+  } else if (widgetType === `Time`) {
+    fmt = TIME_FORMAT;
+  }
+
+  return fmt;
+}
+
+/*
+ * Helper function to turn date value into a Moment object and optionally format it.
+ *
+ * @param {object} value
+ * @param {string} [FORMAT]
+ */
 export function generateMomentObj(value, FORMAT) {
   if (Moment.isMoment(value)) {
     return value.format(FORMAT);

--- a/src/utils/documentListHelper.js
+++ b/src/utils/documentListHelper.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import { push } from 'react-router-redux';
 import { Map } from 'immutable';
-import Moment from 'moment';
+import Moment from 'moment-timezone';
+
 import { getItemsByProperty, nullToEmptyStrings } from './index';
 import { getSelection, getSelectionInstant } from '../reducers/windowHandler';
 
@@ -249,7 +250,7 @@ export function parseToDisplay(fieldsByName) {
 }
 
 // This doesn't set the TZ anymore, as we're handling this globally/in datepicker
-export function parseDateWithCurrenTimezone(value) {
+export function parseDateWithCurrentTimezone(value) {
   if (value) {
     if (Moment.isMoment(value)) {
       return value;
@@ -260,16 +261,17 @@ export function parseDateWithCurrenTimezone(value) {
 }
 
 function parseDateToReadable(fieldsByName) {
-  const dateParse = ['Date', 'ZonedDateTime'];
+  const dateParse = ['Date', 'ZonedDateTime', 'Time', 'Timestamp'];
 
   return Object.keys(fieldsByName).reduce((acc, fieldName) => {
     const field = fieldsByName[fieldName];
     const isDateField = dateParse.indexOf(field.widgetType) > -1;
+
     acc[fieldName] =
       isDateField && field.value
         ? {
             ...field,
-            value: parseDateWithCurrenTimezone(field.value),
+            value: parseDateWithCurrentTimezone(field.value),
           }
         : field;
     return acc;


### PR DESCRIPTION
Related to #2359

Taking into account the usual complexity of our data structures this is as good as it gets. Because filters operate on data directly from the API (instead of stored locally) which doesn't contain widgetType for active filters, everything was always formatted with the default `YYYY-MM-DDTHH:mm:ss.SSSZ` format. So now we have a flat key-value helper map which stores the widgetType of every filter field, which then we can use to format it properly before patching to server.