### PR TITLE
Change date/time format for Timestamp widget

### DIFF
--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -506,7 +506,7 @@ export class RawWidget extends Component {
             <DatePicker
               field={widgetField}
               timeFormat={false}
-              dateFormat={`x`}
+              dateFormat={`L HH:mm:SSS`}
               inputProps={{
                 placeholder: fields[0].emptyText,
                 disabled: readonly,

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -31,6 +31,6 @@ export const DATE_FIELD_FORMATS = {
   ZonedDateTime: 'L LTS',
   DateTime: 'L LTS',
   Time: 'LT',
-  Timestamp: 'x',
+  Timestamp: 'L HH:mm:SSS',
 };
 export const TIME_FIELD_TYPES = ['Time'];


### PR DESCRIPTION
We're not using timestamp anymore, but date with time (including ms).

Related to #2366 