### PR TITLE
Rewrite styling for QuickInput

### DIFF
--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -27,7 +27,8 @@ describe('RawWidget component', () => {
       const wrapper = shallow(<RawWidget {...props} />);
       const html = wrapper.html();
 
-      expect(html).toContain('form-group row');
+      expect(html).toContain('form-group');
+      expect(html).toContain('row');
       expect(html).toContain('input-block');
       expect(wrapper.find('textarea').length).toBe(1);
       expect(html).toContain(fixtures.longText.data1.value)
@@ -176,7 +177,8 @@ describe('RawWidget component', () => {
       const wrapper = shallow(<RawWidget {...props} />);
       const html = wrapper.html();
 
-      expect(html).toContain('form-group row');
+      expect(html).toContain('form-group');
+      expect(html).toContain('row');
       expect(html).toContain('input-block');
       expect(wrapper.find('input').length).toBe(1);
       expect(html).toContain(fixtures.text.data1.value)
@@ -298,7 +300,8 @@ describe('RawWidget component', () => {
       const wrapper = shallow(<RawWidget {...props} />);
       const html = wrapper.html();
 
-      expect(html).toContain('form-group row');
+      expect(html).toContain('form-group');
+      expect(html).toContain('row');
       expect(html).toContain('input-block');
       expect(wrapper.find('input').length).toBe(1);
       expect(html).toContain(fixtures.integer.data1.value)

--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -61,8 +61,12 @@ input {
     &.input-zoom {
         display: flex;
         align-items: center;
-        margin: 0 15px;
+
+        @media (min-width: $breakpoint-md){
+            /*margin: 0 15px;*/
+        }       
     }
+
     .zoom-into:hover {
         text-decoration: underline;
         cursor: pointer;
@@ -104,21 +108,37 @@ input {
 }
 
 .form-flex-align {
-    display: flex;
     flex-wrap: nowrap;
     justify-content: space-between;
-    margin-bottom: .5rem;
+    margin-bottom: 15px;
     align-items: center;
+    position: relative;
 
-    flex:1;
-}
+    > .row {
+        margin-top: 15px;
+    }
 
-/*.form-flex-align > *:not(:last-child){
-    margin-right: .5rem;
-}*/
+    input {
+        flex: 2 1 auto;
+    }
 
-.form-flex-align input {
-    flex: 2 1 auto;
+    @media (min-width: $breakpoint-sm){
+        > .row {
+            margin-top: 0;
+        }
+    }
+
+    @media (min-width: $breakpoint-lg){
+        padding-top: 15px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    @media (min-width: $breakpoint-xl){
+        flex-direction: row;
+        align-items: center;
+    }
 }
 
 .form-group-table {
@@ -475,9 +495,6 @@ input:checked + .input-slider:before {
 @media (max-width: $breakpoint){
     .input-dropdown-container .input-dropdown{
         flex-direction: column;
-    }
-    .input-dropdown .input-icon {
-        top: -9px;
     }
     .input-editable {
         flex: 1 1 50%;

--- a/src/assets/css/inputs.css
+++ b/src/assets/css/inputs.css
@@ -57,6 +57,16 @@ input {
     &.instruction-sent {
         white-space: normal;
     }
+
+    &.input-zoom {
+        display: flex;
+        align-items: center;
+        margin: 0 15px;
+    }
+    .zoom-into:hover {
+        text-decoration: underline;
+        cursor: pointer;
+    }
 }
 
 .form-group {
@@ -103,9 +113,9 @@ input {
     flex:1;
 }
 
-.form-flex-align > *:not(:last-child){
+/*.form-flex-align > *:not(:last-child){
     margin-right: .5rem;
-}
+}*/
 
 .form-flex-align input {
     flex: 2 1 auto;
@@ -786,7 +796,7 @@ input[type=checkbox]:disabled, input[type=radio]:disabled {
     }
 
     .input-field {
-        padding-top: 2px;
+        /*padding-top: 2px;*/
         padding-bottom: 0;
     }
 }
@@ -851,26 +861,6 @@ input[type=checkbox]:disabled, input[type=radio]:disabled {
     z-index: 50;
     margin-top:5px;
     width: 450px;
-}
-
-.quick-input-container {
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    flex:1;
-
-     > * {
-        margin:0;
-        flex:2;
-    }
-
-     .hint {
-        flex:1;
-    }
-
-     > *:first-of-type {
-        flex:8;
-    }
 }
 
 /* Others */

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -1414,11 +1414,6 @@ td.pulse-off input {
     opacity: .2;
 }
 
-.zoom-into:hover {
-    text-decoration: underline;
-    cursor: pointer;
-}
-
 .separator {
     display: flex;
     flex-direction: row;

--- a/src/assets/css/table.css
+++ b/src/assets/css/table.css
@@ -242,7 +242,26 @@
 }
 
 .table-filter-line {
-    height:3rem;
+    .filter-panel-buttons {
+        padding-left: .5rem;
+
+    }
+    @media (min-width: $breakpoint-sm){
+        .filter-panel-buttons {
+            padding-left: 15px;
+        }
+    }
+
+    @media (min-width: $breakpoint-xl){
+        .filter-panel-buttons {
+            padding: 0;
+            margin: 0;
+
+            .close-batch-entry {
+                margin-right: 15px;
+            }
+        }
+    }
 }
 
 .cell-mandatory:focus {
@@ -408,19 +427,32 @@
 
      > * {
         margin:0;
-        /*flex:2;*/
-    }
-
-     .hint {
-        /*flex:1;*/
-    }
-
-     > *:first-of-type {
-        /*flex:8;*/
     }
 
     .form-group {
-        display: flex;
+        > .row {
+            margin-bottom: 15px;
+        }
+    }
+
+    @media (min-width: $breakpoint-sm){
+        margin-top: 15px !important;
+    }
+
+    @media (min-width: $breakpoint-md){
+        > .row {
+            margin-bottom: 0;
+        }
+
+        .input-dropdown-container {
+            min-width: auto;
+        }
+    }
+
+    @media (min-width: $breakpoint-lg){
+        .hint {
+            text-align: right;
+        }
     }
 }
 

--- a/src/assets/css/table.css
+++ b/src/assets/css/table.css
@@ -398,6 +398,32 @@
     }
 }
 
+/* Quick inputs */
+
+.quick-input-container {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    flex:1;
+
+     > * {
+        margin:0;
+        /*flex:2;*/
+    }
+
+     .hint {
+        /*flex:1;*/
+    }
+
+     > *:first-of-type {
+        /*flex:8;*/
+    }
+
+    .form-group {
+        display: flex;
+    }
+}
+
 
 /* Pagination */
 

--- a/src/assets/css/tabs.css
+++ b/src/assets/css/tabs.css
@@ -88,7 +88,6 @@
 
     .collapsible-section {
         transition: height, padding .25s ease-in-out;
-        /*margin: 0;*/
         margin-bottom: 20px;
 
         &.collapsed {
@@ -259,33 +258,42 @@
     height: calc(100% - 55px);
     background-color: #fff;
     z-index: 99;
-}
 
-.tabs-fullscreen.container-fluid {
-    height: calc(100% - 55px);
+    &.container-fluid {
+        height: calc(100% - 55px);
+    }
 }
 
 .tab-pane {
     display: none;
-}
+    
+    &.active {
+        flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+    }
 
-.tab-pane.active {
-    flex-grow: 1;
+    .btn-fullscreen {
+        position: absolute;
+        top: -7px;
+        right: 7px;
 
-    display: flex;
-    flex-direction: column;
-}
+        @media (min-width: $breakpoint-sm){
+            right: 15px;
+        }
+    }
 
-.tab-pane .panel:not(.panel-prompt):not(.table-content-empty) {
-    padding-bottom: 100px;
-}
+    .panel:not(.panel-prompt):not(.table-content-empty) {
+        padding-bottom: 100px;
+    }
 
-.tab-pane .input-dropdown-list {
-    max-height: 100px;
-}
+    .input-dropdown-list {
+        max-height: 100px;
+    }
 
-.tab-pane tbody tr:last-child {
-    border-bottom: 1px solid $brand-border-color;
+    tbody tr:last-child {
+        border-bottom: 1px solid $brand-border-color;
+    }
 }
 
 .tabs-wrapper,

--- a/src/assets/css/variables.css
+++ b/src/assets/css/variables.css
@@ -41,6 +41,8 @@ $brand-icon-off: #D8D8D8;
 
 $input-focused-border: #4b5b64;
 
+$breakpoint-xl: 1400px;
 $breakpoint-lg: 1200px;
 $breakpoint-md: 991px;
-$breakpoint: 543px;
+$breakpoint-sm: 768px;
+$breakpoint: 576px;

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1133,9 +1133,9 @@ class Table extends Component {
     }
 
     return (
-      <div ref={ref => (this.wrapper = ref)} className="table-flex-wrapper">
+      <div ref={ref => (this.wrapper = ref)} className="row table-flex-wrapper">
         <div
-          className={classnames('table-flex-wrapper', {
+          className={classnames('col-12', {
             'table-flex-wrapper-row': mainTable,
           })}
         >
@@ -1170,27 +1170,23 @@ class Table extends Component {
             />
           )}
           {!readonly && (
-            <div className="row">
-              <div className="col-12">
-                <TableFilter
-                  openModal={() => this.openModal(windowId, tabId, 'NEW')}
-                  {...{
-                    toggleFullScreen,
-                    fullScreen,
-                    docId,
-                    tabIndex,
-                    isBatchEntry,
-                    supportQuickInput,
-                    selected,
-                  }}
-                  docType={windowId}
-                  tabId={tabId}
-                  handleBatchEntryToggle={this.handleBatchEntryToggle}
-                  allowCreateNew={tabInfo && tabInfo.allowCreateNew}
-                  wrapperHeight={this.wrapper && this.wrapper.offsetHeight}
-                />
-              </div>
-            </div>
+            <TableFilter
+              openModal={() => this.openModal(windowId, tabId, 'NEW')}
+              {...{
+                toggleFullScreen,
+                fullScreen,
+                docId,
+                tabIndex,
+                isBatchEntry,
+                supportQuickInput,
+                selected,
+              }}
+              docType={windowId}
+              tabId={tabId}
+              handleBatchEntryToggle={this.handleBatchEntryToggle}
+              allowCreateNew={tabInfo && tabInfo.allowCreateNew}
+              wrapperHeight={this.wrapper && this.wrapper.offsetHeight}
+            />
           )}
 
           <div

--- a/src/components/table/TableFilter.js
+++ b/src/components/table/TableFilter.js
@@ -270,7 +270,7 @@ class TableFilter extends Component {
 
         {
           <button
-            className="btn-icon btn-meta-outline-secondary pointer"
+            className="btn-icon btn-meta-outline-secondary pointer btn-fullscreen"
             onClick={toggleFullScreen}
             onMouseEnter={this.showExpandTooltip}
             onMouseLeave={this.hideTooltip}

--- a/src/components/table/TableFilter.js
+++ b/src/components/table/TableFilter.js
@@ -191,9 +191,9 @@ class TableFilter extends Component {
     const tabIndex = fullScreen || modalVisible ? -1 : this.props.tabIndex;
 
     return (
-      <div className="form-flex-align table-filter-line">
+      <div className="table-filter-line">
         <div className="form-flex-align">
-          <div>
+          <div className="row filter-panel-buttons">
             {!isBatchEntry && allowCreateNew && (
               <button
                 className="btn btn-meta-outline-secondary btn-distance btn-sm"
@@ -205,7 +205,7 @@ class TableFilter extends Component {
             )}
             {supportQuickInput && !fullScreen && allowCreateNew && (
               <button
-                className="btn btn-meta-outline-secondary btn-distance btn-sm"
+                className="btn btn-meta-outline-secondary btn-distance btn-sm close-batch-entry"
                 onClick={handleBatchEntryToggle}
                 onMouseEnter={this.showTooltip}
                 onMouseLeave={this.hideTooltip}

--- a/src/components/table/TableQuickInput.js
+++ b/src/components/table/TableQuickInput.js
@@ -171,6 +171,24 @@ class TableQuickInput extends Component {
 
     this.rawWidgets = [];
 
+    const stylingLayout = [
+      {
+        formGroup: `col-sm-6`,
+        label: `quickInput-label`,
+        field: `col`,
+      },
+      {
+        formGroup: `col-sm-3`,
+        label: `col-sm-4`,
+        field: `col-sm-8`,
+      },
+      {
+        formGroup: `col-sm-2`,
+        label: `col-sm-8`,
+        field: `col-sm-4`,
+      },
+    ];
+
     if (data && layout) {
       return layout.map((item, idx) => {
         const widgetData = item.fields.map(elem => data[elem.field] || -1);
@@ -183,6 +201,9 @@ class TableQuickInput extends Component {
                 this.rawWidgets.push(c);
               }
             }}
+            fieldFormGroupClass={stylingLayout[idx].formGroup}
+            fieldLabelClass={stylingLayout[idx].label}
+            fieldInputClass={stylingLayout[idx].field}
             inProgress={inProgress}
             entity={attributeType}
             subentity="quickInput"
@@ -261,11 +282,11 @@ class TableQuickInput extends Component {
     return (
       <form
         onSubmit={this.onSubmit}
-        className="quick-input-container"
+        className="row quick-input-container"
         ref={c => (this.form = c)}
       >
         {this.renderFields(layout, data, docId, 'window', id)}
-        <div className="hint">{"(Press 'Enter' to add)"}</div>
+        <div className="col-sm-2 col-md-1 hint">{"(Press 'Enter' to add)"}</div>
         <button type="submit" className="hidden-up" />
       </form>
     );

--- a/src/components/table/TableQuickInput.js
+++ b/src/components/table/TableQuickInput.js
@@ -173,19 +173,19 @@ class TableQuickInput extends Component {
 
     const stylingLayout = [
       {
-        formGroup: `col-sm-6`,
-        label: `quickInput-label`,
-        field: `col`,
+        formGroup: `col-12 col-lg-4 col-xl-5`,
+        label: `col-12 col-lg-3 quickInput-label`,
+        field: `col-12 col-lg-9`,
       },
       {
-        formGroup: `col-sm-3`,
-        label: `col-sm-4`,
-        field: `col-sm-8`,
+        formGroup: `col-12 col-lg-3 col-xl-3`,
+        label: `col-12 col-sm-4 col-lg-5 col-xl-4`,
+        field: `col-12 col-sm-8 col-lg-7 col-xl-8`,
       },
       {
-        formGroup: `col-sm-2`,
-        label: `col-sm-8`,
-        field: `col-sm-4`,
+        formGroup: `col-12 col-lg-3 col-xl-2`,
+        label: `col-12 col-sm-9 col-lg-7`,
+        field: `col-12 col-sm-3 col-lg-5`,
       },
     ];
 
@@ -286,7 +286,9 @@ class TableQuickInput extends Component {
         ref={c => (this.form = c)}
       >
         {this.renderFields(layout, data, docId, 'window', id)}
-        <div className="col-sm-2 col-md-1 hint">{"(Press 'Enter' to add)"}</div>
+        <div className="col-sm-12 col-md-3 col-lg-2 hint">
+          {`(Press 'Enter' to add)`}
+        </div>
         <button type="submit" className="hidden-up" />
       </form>
     );

--- a/src/components/tabs/Tab.js
+++ b/src/components/tabs/Tab.js
@@ -48,7 +48,7 @@ class Tab extends Component {
   render() {
     const { children } = this.props;
 
-    return <div className="table-flex-wrapper">{children}</div>;
+    return <div>{children}</div>;
   }
 }
 

--- a/src/components/widget/PropTypes.js
+++ b/src/components/widget/PropTypes.js
@@ -1,5 +1,61 @@
 import PropTypes from 'prop-types';
 
+/**
+ * @typedef {object} Props Component props
+ * @prop {func} dispatch
+ * @prop {bool} inProgress
+ * @prop {bool} autoFocus
+ * @prop {bool} textSelected
+ * @prop {bool} listenOnKeys
+ * @prop {func} listenOnKeysFalse
+ * @prop {func} listenOnKeysTrue
+ * @prop {array} widgetData
+ * @prop {func} handleFocus
+ * @prop {func} handlePatch
+ * @prop {func} handleBlur
+ * @prop {func} handleProcess
+ * @prop {func} handleChange
+ * @prop {func} hanndleBackdropLock
+ * @prop {func} handleZoomInto
+ * @prop {string} tabId
+ * @prop {string} viewId
+ * @prop {string} rowId
+ * @prop {string|number} dataId
+ * @prop {string} windowType
+ * @prop {string} caption
+ * @prop {string} gridAlign
+ * @prop {string} type
+ * @prop {bool} updated
+ * @prop {bool} isModal
+ * @prop {bool} modalVisible
+ * @prop {bool} filterWidget
+ * @prop {string} filterId
+ * @prop {number} id
+ * @prop {bool} range
+ * @prop {func} onShow
+ * @prop {func} onHide
+ * @prop {string} subentity
+ * @prop {string} subentityId
+ * @prop {number} tabIndex
+ * @prop {func} dropdownOpenCallback
+ * @prop {bool} fullScreen
+ * @prop {string} widgetType
+ * @prop {array} fields
+ * @prop {string} icon
+ * @prop {string} entity
+ * @prop {*} data
+ * @prop {func} closeTableField
+ * @prop {bool} attribute
+ * @prop {bool} allowShowPassword
+ * @prop {string} buttonProcessId
+ * @prop {func} onBlurWidget
+ * @prop {string|array} defaultValue
+ * @prop {bool} noLabel
+ * @prop {bool} isOpenDatePicker
+ * @prop {number} forceHeight
+ * @prop {bool} dataEntry
+ * @prop {bool} lastFormField
+ */
 export const RawWidgetPropTypes = {
   dispatch: PropTypes.func.isRequired,
   inProgress: PropTypes.bool,

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -1029,93 +1029,91 @@ export class RawWidget extends Component {
       }
     }
 
+    const labelProps = {};
+
+    if (!noLabel && caption && fields[0].supportZoomInto) {
+      labelProps.onClick = () => handleZoomInto(fields[0].field);
+    }
+
     return (
       <div
         className={classnames(
           'form-group',
           formGroupClass,
           {
-            row: !quickInput,
             'form-group-table': rowId && !isModal,
-            [`${formGroupClass}`]: formGroupClass,
           },
           widgetFieldsName
         )}
       >
-        {captionElement || null}
-        {!noLabel && caption && (
+        <div className={classnames({ row: true })}>
+          {captionElement || null}
+          {!noLabel && caption && (
+            <label
+              className={classnames('form-control-label', labelClass, {
+                'input-zoom': quickInput && fields[0].supportZoomInto,
+                'zoom-into': fields[0].supportZoomInto,
+              })}
+              title={description || caption}
+              {...labelProps}
+            >
+              {caption}
+            </label>
+          )}
           <div
-            key="title"
-            className={classnames('form-control-label', labelClass, {
-              'input-zoom': quickInput && fields[0].supportZoomInto,
-            })}
-            title={description || caption}
+            className={fieldClass}
+            onMouseEnter={() => this.handleErrorPopup(true)}
+            onMouseLeave={() => this.handleErrorPopup(false)}
           >
-            {fields[0].supportZoomInto ? (
-              <span
-                className="zoom-into"
-                onClick={() => handleZoomInto(fields[0].field)}
+            {!clearedFieldWarning && warning && (
+              <div
+                className={classnames('field-warning', {
+                  'field-warning-message': warning,
+                  'field-error-message': warning && warning.error,
+                })}
+                onMouseEnter={() => this.toggleTooltip(true)}
+                onMouseLeave={() => this.toggleTooltip(false)}
               >
-                {caption}
-              </span>
-            ) : (
-              caption
+                <span>{warning.caption}</span>
+                <i
+                  className="meta-icon-close-alt"
+                  onClick={() => this.clearFieldWarning(warning)}
+                />
+                {warning.message && tooltipToggled && (
+                  <Tooltips action={warning.message} type="" />
+                )}
+              </div>
+            )}
+
+            <div
+              className={classnames('input-body-container', {
+                focused: isEdited,
+              })}
+              title={valueDescription}
+            >
+              <ReactCSSTransitionGroup
+                transitionName="fade"
+                transitionEnterTimeout={200}
+                transitionLeaveTimeout={200}
+              >
+                {errorPopup &&
+                  validStatus &&
+                  !validStatus.valid &&
+                  !validStatus.initialValue &&
+                  this.renderErrorPopup(validStatus.reason)}
+              </ReactCSSTransitionGroup>
+              {widgetBody}
+            </div>
+            {fields[0].devices && !widgetData[0].readonly && (
+              <DevicesWidget
+                devices={fields[0].devices}
+                tabIndex={1}
+                handleChange={value =>
+                  handlePatch && handlePatch(fields[0].field, value)
+                }
+              />
             )}
           </div>
-        )}
-        <div
-          className={fieldClass}
-          onMouseEnter={() => this.handleErrorPopup(true)}
-          onMouseLeave={() => this.handleErrorPopup(false)}
-        >
-          {!clearedFieldWarning && warning && (
-            <div
-              className={classnames('field-warning', {
-                'field-warning-message': warning,
-                'field-error-message': warning && warning.error,
-              })}
-              onMouseEnter={() => this.toggleTooltip(true)}
-              onMouseLeave={() => this.toggleTooltip(false)}
-            >
-              <span>{warning.caption}</span>
-              <i
-                className="meta-icon-close-alt"
-                onClick={() => this.clearFieldWarning(warning)}
-              />
-              {warning.message && tooltipToggled && (
-                <Tooltips action={warning.message} type="" />
-              )}
-            </div>
-          )}
-
-          <div
-            className={classnames('input-body-container', {
-              focused: isEdited,
-            })}
-            title={valueDescription}
-          >
-            <ReactCSSTransitionGroup
-              transitionName="fade"
-              transitionEnterTimeout={200}
-              transitionLeaveTimeout={200}
-            >
-              {errorPopup &&
-                validStatus &&
-                !validStatus.valid &&
-                !validStatus.initialValue &&
-                this.renderErrorPopup(validStatus.reason)}
-            </ReactCSSTransitionGroup>
-            {widgetBody}
-          </div>
-          {fields[0].devices && !widgetData[0].readonly && (
-            <DevicesWidget
-              devices={fields[0].devices}
-              tabIndex={1}
-              handleChange={value =>
-                handlePatch && handlePatch(fields[0].field, value)
-              }
-            />
-          )}
         </div>
       </div>
     );

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -1046,7 +1046,7 @@ export class RawWidget extends Component {
           widgetFieldsName
         )}
       >
-        <div className={classnames({ row: true })}>
+        <div className="row">
           {captionElement || null}
           {!noLabel && caption && (
             <label

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -47,10 +47,6 @@ export class RawWidget extends Component {
     this.generateMomentObj = generateMomentObj.bind(this);
   }
 
-  /**
-   * @method componentDidMount
-   * @summary ToDo: Describe the method.
-   */
   componentDidMount() {
     const { autoFocus, textSelected } = this.props;
     const { rawWidget } = this;
@@ -943,10 +939,6 @@ export class RawWidget extends Component {
     }
   };
 
-  /**
-   * @method render
-   * @summary ToDo: Describe the method.
-   */
   render() {
     const {
       caption,
@@ -962,6 +954,10 @@ export class RawWidget extends Component {
       widgetType,
       handleZoomInto,
       dataEntry,
+      subentity,
+      fieldFormGroupClass,
+      fieldLabelClass,
+      fieldInputClass,
     } = this.props;
     const {
       errorPopup,
@@ -971,6 +967,7 @@ export class RawWidget extends Component {
     } = this.state;
     const widgetBody = this.renderWidget();
     const { validStatus, warning } = widgetData[0];
+    const quickInput = subentity === 'quickInput';
 
     // We have to hardcode that exception in case of having
     // wrong two line rendered one line widgets
@@ -1002,32 +999,45 @@ export class RawWidget extends Component {
       .map(field => 'form-field-' + field.field)
       .join(' ');
 
-    let labelClass = dataEntry ? 'col-sm-5' : '';
-    if (!labelClass) {
-      labelClass =
-        type === 'primary' && !oneLineException
-          ? 'col-sm-12 panel-title'
-          : type === 'primaryLongLabels'
-          ? 'col-sm-6'
-          : 'col-sm-3';
-    }
+    let labelClass;
+    let fieldClass;
+    let formGroupClass = '';
 
-    let fieldClass = dataEntry ? 'col-sm-7' : '';
-    if (!fieldClass) {
-      fieldClass =
-        ((type === 'primary' || noLabel) && !oneLineException
-          ? 'col-sm-12 '
-          : type === 'primaryLongLabels'
-          ? 'col-sm-6'
-          : 'col-sm-9 ') + (fields[0].devices ? 'form-group-flex' : '');
+    if (quickInput) {
+      labelClass = fieldLabelClass;
+      fieldClass = fieldInputClass;
+      formGroupClass = fieldFormGroupClass;
+    } else {
+      labelClass = dataEntry ? 'col-sm-5' : '';
+      if (!labelClass) {
+        labelClass =
+          type === 'primary' && !oneLineException
+            ? 'col-sm-12 panel-title'
+            : type === 'primaryLongLabels'
+            ? 'col-sm-6'
+            : 'col-sm-3';
+      }
+
+      fieldClass = dataEntry ? 'col-sm-7' : '';
+      if (!fieldClass) {
+        fieldClass =
+          ((type === 'primary' || noLabel) && !oneLineException
+            ? 'col-sm-12 '
+            : type === 'primaryLongLabels'
+            ? 'col-sm-6'
+            : 'col-sm-9 ') + (fields[0].devices ? 'form-group-flex' : '');
+      }
     }
 
     return (
       <div
         className={classnames(
-          'form-group row ',
+          'form-group',
+          formGroupClass,
           {
+            row: !quickInput,
             'form-group-table': rowId && !isModal,
+            [`${formGroupClass}`]: formGroupClass,
           },
           widgetFieldsName
         )}
@@ -1036,7 +1046,9 @@ export class RawWidget extends Component {
         {!noLabel && caption && (
           <div
             key="title"
-            className={classnames('form-control-label', labelClass)}
+            className={classnames('form-control-label', labelClass, {
+              'input-zoom': quickInput && fields[0].supportZoomInto,
+            })}
             title={description || caption}
           >
             {fields[0].supportZoomInto ? (
@@ -1110,62 +1122,6 @@ export class RawWidget extends Component {
   }
 }
 
-/**
- * @typedef {object} Props Component props
- * @prop {func} dispatch
- * @prop {bool} inProgress
- * @prop {bool} autoFocus
- * @prop {bool} textSelected
- * @prop {bool} listenOnKeys
- * @prop {func} listenOnKeysFalse
- * @prop {func} listenOnKeysTrue
- * @prop {array} widgetData
- * @prop {func} handleFocus
- * @prop {func} handlePatch
- * @prop {func} handleBlur
- * @prop {func} handleProcess
- * @prop {func} handleChange
- * @prop {func} hanndleBackdropLock
- * @prop {func} handleZoomInto
- * @prop {string} tabId
- * @prop {string} viewId
- * @prop {string} rowId
- * @prop {string|number} dataId
- * @prop {string} windowType
- * @prop {string} caption
- * @prop {string} gridAlign
- * @prop {string} type
- * @prop {bool} updated
- * @prop {bool} isModal
- * @prop {bool} modalVisible
- * @prop {bool} filterWidget
- * @prop {string} filterId
- * @prop {number} id
- * @prop {bool} range
- * @prop {func} onShow
- * @prop {func} onHide
- * @prop {string} subentity
- * @prop {string} subentityId
- * @prop {number} tabIndex
- * @prop {func} dropdownOpenCallback
- * @prop {bool} fullScreen
- * @prop {string} widgetType
- * @prop {array} fields
- * @prop {string} icon
- * @prop {string} entity
- * @prop {*} data
- * @prop {func} closeTableField
- * @prop {bool} attribute
- * @prop {bool} allowShowPassword
- * @prop {string} buttonProcessId
- * @prop {func} onBlurWidget
- * @prop {string|array} defaultValue
- * @prop {bool} noLabel
- * @prop {bool} isOpenDatePicker
- * @prop {number} forceHeight
- * @prop {bool} dataEntry
- * @prop {bool} lastFormField
- */
 RawWidget.propTypes = RawWidgetPropTypes;
 RawWidget.defaultProps = RawWidgetDefaultProps;
 


### PR DESCRIPTION
After adding more fields this whole section was really cramped. Now it's fully responsive and on smaller screens the layout is different than when the view is bigger. Thanks to that it's not as packed. Most of the problems were caused by the mobile views, but looks ok to me now.

Before:

<img width="521" alt="Screen Shot 2019-10-08 at 12 01 21" src="https://user-images.githubusercontent.com/513460/66417230-d7ebd500-e9ff-11e9-9978-49a14f1810d4.png">

After:

<img width="408" alt="Screen Shot 2019-10-08 at 02 05 35" src="https://user-images.githubusercontent.com/513460/66417247-e1753d00-e9ff-11e9-898f-1d1c1ac3dbf4.png">

https://recordit.co/M3BUm4XNiZ
