### PR TITLE
Fix refreshing rows when changing pages + performance improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "moment": "2.24.0",
     "moment-timezone": "0.5.26",
     "numeral": "2.0.6",
-    "object-hash": "^1.3.1",
+    "object-hash": "2.0.0",
     "prop-types": "15.7.2",
     "quagga": "0.12.1",
     "query-string": "5.0.1",

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -656,9 +656,15 @@ class Table extends Component {
     }
   };
 
-  handleClick = (e, keyProperty, item) => {
-    const { onSelectionChanged } = this.props;
+  handleClick = (e, item) => {
+    const {
+      onSelectionChanged,
+      openIncludedViewOnSelect,
+      showIncludedViewOnSelect,
+      keyProperty,
+    } = this.props;
     const id = item[keyProperty];
+    let selectionValue = false;
 
     if (e.button === 0) {
       const { selected } = this.state;
@@ -692,9 +698,20 @@ class Table extends Component {
         onSelectionChanged(newSelection);
       }
 
-      return newSelection.length > 0;
+      selectionValue = newSelection.length > 0;
     }
-    return true;
+    selectionValue = true;
+
+    if (openIncludedViewOnSelect) {
+      showIncludedViewOnSelect({
+        showIncludedView: selectionValue && item.supportIncludedViews,
+        forceClose: !selectionValue,
+        windowType: item.supportIncludedViews
+          ? item.includedView.windowType || item.includedView.windowId
+          : null,
+        viewId: item.supportIncludedViews ? item.includedView.viewId : '',
+      });
+    }
   };
 
   handleRightClick = (e, id, fieldName, supportZoomInto, supportFieldEdit) => {
@@ -959,8 +976,6 @@ class Table extends Component {
       entity,
       indentSupported,
       collapsible,
-      showIncludedViewOnSelect,
-      openIncludedViewOnSelect,
       viewId,
       supportOpenRecord,
     } = this.props;
@@ -998,6 +1013,7 @@ class Table extends Component {
           collapsible,
           viewId,
           supportOpenRecord,
+          item,
         }}
         dataKey={hash(item.fieldsByName)}
         key={`${i}-${viewId}`}
@@ -1012,32 +1028,12 @@ class Table extends Component {
             this.rowRefs[keyProp] = c.wrappedInstance;
           }
         }}
+        keyProperty={item[keyProperty]}
         rowId={item[keyProperty]}
         tabId={tabId}
         onDoubleClick={this.handleDoubleClick}
-        onClick={e => {
-          const selected = this.handleClick(e, keyProperty, item);
-
-          if (openIncludedViewOnSelect) {
-            showIncludedViewOnSelect({
-              showIncludedView: selected && item.supportIncludedViews,
-              forceClose: !selected,
-              windowType: item.supportIncludedViews
-                ? item.includedView.windowType || item.includedView.windowId
-                : null,
-              viewId: item.supportIncludedViews ? item.includedView.viewId : '',
-            });
-          }
-        }}
-        handleRightClick={(e, fieldName, supportZoomInto, supportFieldEdit) =>
-          this.handleRightClick(
-            e,
-            item[keyProperty],
-            fieldName,
-            !!supportZoomInto,
-            supportFieldEdit
-          )
-        }
+        onClick={this.handleClick}
+        handleRightClick={this.handleRightClick}
         changeListenOnTrue={() => this.changeListen(true)}
         changeListenOnFalse={() => this.changeListen(false)}
         newRow={i === rows.length - 1 ? newRow : false}

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import classnames from 'classnames';
 import currentDevice from 'current-device';
 import counterpart from 'counterpart';
-import hash from 'object-hash';
+import uuid from 'uuid/v4';
 
 import { deleteRequest } from '../../actions/GenericActions';
 import {
@@ -258,7 +258,9 @@ class Table extends Component {
             }
           });
 
-          const updatedState = {};
+          const updatedState = {
+            dataHash: uuid(),
+          };
 
           if (mapCollapsed.length) {
             updatedState.collapsedArrayMap = mapCollapsed;
@@ -283,6 +285,7 @@ class Table extends Component {
 
       this.setState({
         rows: rowsData,
+        dataHash: uuid(),
         pendingInit: !rowData.get(`${tabId}`),
       });
     }
@@ -980,7 +983,13 @@ class Table extends Component {
       supportOpenRecord,
     } = this.props;
 
-    const { selected, rows, collapsedRows, collapsedParentsRows } = this.state;
+    const {
+      selected,
+      rows,
+      collapsedRows,
+      collapsedParentsRows,
+      dataHash,
+    } = this.state;
 
     if (!rows || !rows.length) return null;
 
@@ -1015,7 +1024,7 @@ class Table extends Component {
           supportOpenRecord,
           item,
         }}
-        dataKey={hash(item.fieldsByName)}
+        dataHash={dataHash}
         key={`${i}-${viewId}`}
         collapsed={
           collapsedParentsRows &&

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -170,6 +170,38 @@ class TableCell extends PureComponent {
     }
   };
 
+  handleKeyDown = e => {
+    const { handleKeyDown, property, widgetData } = this.props;
+
+    handleKeyDown(e, property, widgetData[0]);
+  };
+
+  handleRightClick = e => {
+    const {
+      handleRightClick,
+      property,
+      supportZoomInto,
+      supportFieldEdit,
+      keyProperty,
+    } = this.props;
+
+    handleRightClick(
+      e,
+      keyProperty,
+      property,
+      !!supportZoomInto,
+      supportFieldEdit
+    );
+  };
+
+  onDoubleClick = e => {
+    const { isEditable, property, widgetData, handleDoubleClick } = this.props;
+
+    if (isEditable) {
+      handleDoubleClick(e, property, true, widgetData[0]);
+    }
+  };
+
   render() {
     const {
       isEdited,
@@ -181,8 +213,6 @@ class TableCell extends PureComponent {
       rowId,
       tabId,
       property,
-      handleDoubleClick,
-      handleKeyDown,
       updatedRow,
       tabIndex,
       entity,
@@ -191,7 +221,6 @@ class TableCell extends PureComponent {
       listenOnKeysTrue,
       closeTableField,
       getSizeClass,
-      handleRightClick,
       mainTable,
       onCellChange,
       viewId,
@@ -259,9 +288,9 @@ class TableCell extends PureComponent {
       <td
         tabIndex={modalVisible ? -1 : tabIndex}
         ref={c => (this.cell = c)}
-        onDoubleClick={handleDoubleClick}
-        onKeyDown={handleKeyDown}
-        onContextMenu={handleRightClick}
+        onDoubleClick={this.onDoubleClick}
+        onKeyDown={this.handleKeyDown}
+        onContextMenu={this.handleRightClick}
         className={classnames(
           {
             [`text-${item.gridAlign}`]: item.gridAlign,

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -132,16 +132,35 @@ class TableCell extends PureComponent {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const { widgetData, updateRow, readonly, rowId } = this.props;
+    const {
+      getWidgetData,
+      updateRow,
+      readonly,
+      rowId,
+      item,
+      isEditable,
+      supportFieldEdit,
+    } = this.props;
+    const {
+      item: nextItem,
+      isEditable: nextIsEditable,
+      supportFieldEdit: nextSupportFieldEdit,
+    } = nextProps;
     // We should avoid highlighting when whole row is exchanged (sorting)
     if (rowId !== nextProps.rowId) {
       return;
     }
+    const widgetData = getWidgetData(item, isEditable, supportFieldEdit);
+    const nextWidgetData = getWidgetData(
+      nextItem,
+      nextIsEditable,
+      nextSupportFieldEdit
+    );
 
     if (
       !readonly &&
       JSON.stringify(widgetData[0].value) !==
-        JSON.stringify(nextProps.widgetData[0].value)
+        JSON.stringify(nextWidgetData[0].value)
     ) {
       updateRow();
     }
@@ -205,9 +224,11 @@ class TableCell extends PureComponent {
   render() {
     const {
       isEdited,
+      isEditable,
+      supportFieldEdit,
       cellExtended,
       extendLongText,
-      widgetData,
+      getWidgetData,
       item,
       windowId,
       rowId,
@@ -228,6 +249,7 @@ class TableCell extends PureComponent {
       onClickOutside,
       isGerman,
     } = this.props;
+    const widgetData = getWidgetData(item, isEditable, supportFieldEdit);
 
     const docId = `${this.props.docId}`;
     const { tooltipToggled } = this.state;

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -133,35 +133,20 @@ class TableCell extends PureComponent {
 
   UNSAFE_componentWillReceiveProps(nextProps) {
     const {
-      getWidgetData,
       updateRow,
       readonly,
       rowId,
-      item,
-      isEditable,
-      supportFieldEdit,
+      tdValue,
     } = this.props;
     const {
-      item: nextItem,
-      isEditable: nextIsEditable,
-      supportFieldEdit: nextSupportFieldEdit,
+      tdValue: nextTdValue,
     } = nextProps;
     // We should avoid highlighting when whole row is exchanged (sorting)
     if (rowId !== nextProps.rowId) {
       return;
     }
-    const widgetData = getWidgetData(item, isEditable, supportFieldEdit);
-    const nextWidgetData = getWidgetData(
-      nextItem,
-      nextIsEditable,
-      nextSupportFieldEdit
-    );
 
-    if (
-      !readonly &&
-      JSON.stringify(widgetData[0].value) !==
-        JSON.stringify(nextWidgetData[0].value)
-    ) {
+    if (!readonly && tdValue !== nextTdValue) {
       updateRow();
     }
   }
@@ -347,25 +332,28 @@ class TableCell extends PureComponent {
         {isEdited ? (
           <MasterWidget
             {...item}
+            {...{
+              getWidgetData,
+              viewId,
+              rowId,
+              widgetData,
+              closeTableField,
+              isOpenDatePicker,
+              listenOnKeys,
+              listenOnKeysFalse,
+              listenOnKeysTrue,
+              onClickOutside,
+            }}
             entity={entityEffective}
             dateFormat={isDateField}
             dataId={mainTable ? null : docId}
-            widgetData={widgetData}
             windowType={windowId}
             isMainTable={mainTable}
-            rowId={rowId}
-            viewId={viewId}
             tabId={mainTable ? null : tabId}
             noLabel={true}
             gridAlign={item.gridAlign}
             handleBackdropLock={this.handleBackdropLock}
-            onClickOutside={onClickOutside}
-            listenOnKeys={listenOnKeys}
-            listenOnKeysTrue={listenOnKeysTrue}
-            listenOnKeysFalse={listenOnKeysFalse}
             onChange={mainTable ? onCellChange : null}
-            closeTableField={closeTableField}
-            isOpenDatePicker={isOpenDatePicker}
             ref={c => {
               this.widget = c && c.getWrappedInstance();
             }}

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -132,15 +132,8 @@ class TableCell extends PureComponent {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const {
-      updateRow,
-      readonly,
-      rowId,
-      tdValue,
-    } = this.props;
-    const {
-      tdValue: nextTdValue,
-    } = nextProps;
+    const { updateRow, readonly, rowId, tdValue } = this.props;
+    const { tdValue: nextTdValue } = nextProps;
     // We should avoid highlighting when whole row is exchanged (sorting)
     if (rowId !== nextProps.rowId) {
       return;

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -190,7 +190,15 @@ class TableCell extends PureComponent {
   };
 
   handleKeyDown = e => {
-    const { handleKeyDown, property, widgetData } = this.props;
+    const {
+      handleKeyDown,
+      property,
+      item,
+      getWidgetData,
+      isEditable,
+      supportFieldEdit,
+    } = this.props;
+    const widgetData = getWidgetData(item, isEditable, supportFieldEdit);
 
     handleKeyDown(e, property, widgetData[0]);
   };
@@ -214,7 +222,15 @@ class TableCell extends PureComponent {
   };
 
   onDoubleClick = e => {
-    const { isEditable, property, widgetData, handleDoubleClick } = this.props;
+    const {
+      property,
+      item,
+      getWidgetData,
+      isEditable,
+      supportFieldEdit,
+      handleDoubleClick,
+    } = this.props;
+    const widgetData = getWidgetData(item, isEditable, supportFieldEdit);
 
     if (isEditable) {
       handleDoubleClick(e, property, true, widgetData[0]);
@@ -382,9 +398,11 @@ class TableCell extends PureComponent {
 }
 
 TableCell.propTypes = {
+  isEditable: PropTypes.bool,
   cellExtended: PropTypes.bool,
   extendLongText: PropTypes.number,
   property: PropTypes.string,
+  getWidgetData: PropTypes.func,
   handleRightClick: PropTypes.func,
   handleKeyDown: PropTypes.func,
   handleDoubleClick: PropTypes.func,

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -47,7 +47,7 @@ class TableItem extends PureComponent {
       this.handleCellExtend();
     }
 
-    if (this.props.dataHash!== prevProps.dataHash) {
+    if (this.props.dataHash !== prevProps.dataHash) {
       this.setState({
         editedCells: {},
       });
@@ -539,7 +539,7 @@ TableItem.propTypes = {
   processed: PropTypes.bool,
   notSaved: PropTypes.bool,
   isSelected: PropTypes.bool,
-  odd: PropTypes.bool,
+  odd: PropTypes.number,
   caption: PropTypes.string,
   dataHash: PropTypes.string.isRequired,
   key: PropTypes.string,

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -13,19 +13,6 @@ import { shouldRenderColumn } from '../../utils/tableHelpers';
 import { WithMobileDoubleTap } from '../WithMobileDoubleTap';
 
 class TableItem extends PureComponent {
-  static getDerivedStateFromProps(props, state) {
-    // Any time the dataKey changes,
-    // Reset edited cells as we have a completely
-    // new dataset
-    if (props.dataKey !== state.dataKey) {
-      return {
-        ...state,
-        editedCells: {},
-      };
-    }
-    return state;
-  }
-
   constructor(props) {
     super(props);
 
@@ -44,7 +31,6 @@ class TableItem extends PureComponent {
 
     this.state = {
       edited: '',
-      dataKey: props.dataKey,
       activeCell: '',
       updatedRow: false,
       listenOnKeys: true,
@@ -59,6 +45,12 @@ class TableItem extends PureComponent {
 
     if (multilineText && this.props.isSelected !== prevProps.isSelected) {
       this.handleCellExtend();
+    }
+
+    if (this.props.dataKey !== prevProps.dataKey) {
+      this.setState({
+        editedCells: {},
+      });
     }
   }
 
@@ -539,6 +531,7 @@ TableItem.propTypes = {
   processed: PropTypes.bool,
   notSaved: PropTypes.bool,
   isSelected: PropTypes.bool,
+  dataKey: PropTypes.string.isRequired,
 };
 
 export default connect(

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -47,7 +47,7 @@ class TableItem extends PureComponent {
       this.handleCellExtend();
     }
 
-    if (this.props.dataKey !== prevProps.dataKey) {
+    if (this.props.dataHash!== prevProps.dataHash) {
       this.setState({
         editedCells: {},
       });
@@ -534,11 +534,15 @@ TableItem.propTypes = {
   handleSelect: PropTypes.func,
   onDoubleClick: PropTypes.func,
   indentSupported: PropTypes.bool,
+  collapsible: PropTypes.bool,
   collapsed: PropTypes.bool,
   processed: PropTypes.bool,
   notSaved: PropTypes.bool,
   isSelected: PropTypes.bool,
-  dataKey: PropTypes.string.isRequired,
+  odd: PropTypes.bool,
+  caption: PropTypes.string,
+  dataHash: PropTypes.string.isRequired,
+  key: PropTypes.string,
 };
 
 export default connect(

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -218,6 +218,18 @@ class TableItem extends PureComponent {
     }
   };
 
+  handleClick = e => {
+    const { onClick, item } = this.props;
+
+    onClick(e, item);
+  };
+
+  handleClickOutside = e => {
+    const { changeListenOnTrue } = this.props;
+    this.handleEditProperty(e);
+    changeListenOnTrue();
+  };
+
   handleCellExtend = () => {
     this.setState({
       cellsExtended: !this.state.cellsExtended,
@@ -234,7 +246,6 @@ class TableItem extends PureComponent {
       tabId,
       mainTable,
       newRow,
-      changeListenOnTrue,
       tabIndex,
       entity,
       getSizeClass,
@@ -242,6 +253,7 @@ class TableItem extends PureComponent {
       caption,
       colspan,
       viewId,
+      keyProperty,
       isSelected,
     } = this.props;
     const {
@@ -315,38 +327,26 @@ class TableItem extends PureComponent {
                   viewId,
                   extendLongText,
                   property,
+                  isEditable,
+                  supportZoomInto,
+                  supportFieldEdit,
+                  handleRightClick,
+                  keyProperty,
                 }}
                 cellExtended={cellsExtended}
                 key={`${rowId}-${property}`}
                 isRowSelected={isSelected}
                 isEdited={isEdited}
-                handleDoubleClick={e => {
-                  if (isEditable) {
-                    this.handleEditProperty(e, property, true, widgetData[0]);
-                  }
-                }}
-                onClickOutside={e => {
-                  this.handleEditProperty(e);
-                  changeListenOnTrue();
-                }}
+                handleDoubleClick={this.handleEditProperty}
+                onClickOutside={this.handleClickOutside}
                 onCellChange={this.onCellChange}
                 onCellExtend={this.handleCellExtend}
                 updatedRow={updatedRow || newRow}
                 updateRow={this.updateRow}
-                handleKeyDown={e =>
-                  this.handleKeyDown(e, property, widgetData[0])
-                }
+                handleKeyDown={this.handleKeyDown}
                 listenOnKeysTrue={this.listenOnKeysTrue}
                 listenOnKeysFalse={this.listenOnKeysFalse}
-                closeTableField={e => this.closeTableField(e)}
-                handleRightClick={e =>
-                  handleRightClick(
-                    e,
-                    property,
-                    supportZoomInto,
-                    supportFieldEdit
-                  )
-                }
+                closeTableField={this.closeTableField}
               />
             );
           }
@@ -482,7 +482,6 @@ class TableItem extends PureComponent {
     const {
       key,
       isSelected,
-      onClick,
       odd,
       indentSupported,
       indent,
@@ -498,7 +497,7 @@ class TableItem extends PureComponent {
       <WithMobileDoubleTap>
         <tr
           key={key}
-          onClick={onClick}
+          onClick={this.handleClick}
           onDoubleClick={this.handleDoubleClick}
           className={classnames({
             'row-selected': isSelected,

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -243,7 +243,7 @@ class TableItem extends PureComponent {
 
     return item.fields.map(prop => {
       if (cells) {
-        let cellWidget = cells[prop.field] || -1;
+        let cellWidget = cells[prop.field] || null;
 
         if (
           isEditable ||
@@ -259,8 +259,7 @@ class TableItem extends PureComponent {
         return cellWidget;
       }
 
-      // @TODO: Why -1 ? - Kuba
-      return -1;
+      return null;
     });
   };
 

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -241,7 +241,7 @@ class TableItem extends PureComponent {
     const { editedCells } = this.state;
     const cells = merge({}, fieldsByName, editedCells);
 
-    return item.fields.map(prop => {
+    const widgetData = item.fields.reduce((result, prop) => {
       if (cells) {
         let cellWidget = cells[prop.field] || null;
 
@@ -256,11 +256,19 @@ class TableItem extends PureComponent {
             readonly: false,
           };
         }
-        return cellWidget;
-      }
 
-      return null;
-    });
+        if (cellWidget) {
+          result.push(cellWidget);
+        }
+      }
+      return result;
+    }, []);
+
+    if (widgetData.length) {
+      return widgetData;
+    }
+
+    return [{}];
   };
 
   renderCells = () => {
@@ -346,7 +354,9 @@ class TableItem extends PureComponent {
                   keyProperty,
                 }}
                 tdValue={
-                  widgetData ? JSON.stringify(widgetData[0].value) : null
+                  widgetData[0].value
+                    ? JSON.stringify(widgetData[0].value)
+                    : null
                 }
                 getWidgetData={this.getWidgetData}
                 cellExtended={cellsExtended}

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -236,6 +236,34 @@ class TableItem extends PureComponent {
     });
   };
 
+  getWidgetData = (item, isEditable, supportFieldEdit) => {
+    const { fieldsByName } = this.props;
+    const { editedCells } = this.state;
+    const cells = merge({}, fieldsByName, editedCells);
+
+    return item.fields.map(prop => {
+      if (cells) {
+        let cellWidget = cells[prop.field] || -1;
+
+        if (
+          isEditable ||
+          (supportFieldEdit && typeof cellWidget === 'object')
+        ) {
+          cellWidget = {
+            ...cellWidget,
+            widgetType: item.widgetType,
+            displayed: true,
+            readonly: false,
+          };
+        }
+        return cellWidget;
+      }
+
+      // @TODO: Why -1 ? - Kuba
+      return -1;
+    });
+  };
+
   renderCells = () => {
     const {
       cols,
@@ -287,26 +315,6 @@ class TableItem extends PureComponent {
             const isEdited = edited === property;
             const extendLongText = multilineText ? multilineTextLines : 0;
 
-            let widgetData = item.fields.map(prop => {
-              if (cells) {
-                let cellWidget = cells[prop.field] || -1;
-
-                if (
-                  isEditable ||
-                  (supportFieldEdit && typeof cellWidget === 'object')
-                ) {
-                  cellWidget = {
-                    ...cellWidget,
-                    widgetType: item.widgetType,
-                    displayed: true,
-                    readonly: false,
-                  };
-                }
-                return cellWidget;
-              }
-              return -1;
-            });
-            // HACK: Color fields should always be readonly
             isEditable = item.widgetType === 'Color' ? false : isEditable;
 
             return (
@@ -319,7 +327,6 @@ class TableItem extends PureComponent {
                   rowId,
                   tabId,
                   item,
-                  widgetData,
                   tabIndex,
                   listenOnKeys,
                   caption,
@@ -333,6 +340,7 @@ class TableItem extends PureComponent {
                   handleRightClick,
                   keyProperty,
                 }}
+                getWidgetData={this.getWidgetData}
                 cellExtended={cellsExtended}
                 key={`${rowId}-${property}`}
                 isRowSelected={isSelected}

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -317,6 +317,12 @@ class TableItem extends PureComponent {
 
             isEditable = item.widgetType === 'Color' ? false : isEditable;
 
+            const widgetData = this.getWidgetData(
+              item,
+              isEditable,
+              supportFieldEdit
+            );
+
             return (
               <TableCell
                 {...{
@@ -340,6 +346,9 @@ class TableItem extends PureComponent {
                   handleRightClick,
                   keyProperty,
                 }}
+                tdValue={
+                  widgetData ? JSON.stringify(widgetData[0].value) : null
+                }
                 getWidgetData={this.getWidgetData}
                 cellExtended={cellsExtended}
                 key={`${rowId}-${property}`}


### PR DESCRIPTION
Apart of introducing a better solution to #2370, which doesn't impact the performance (at least) visibly this also cleans up and removes some unnecessary code complexity that caused thousands of re-renders that could be avoided. 

Here's an output from `why-did-you-update` performance measuring plugin (https://www.npmjs.com/package/why-did-you-update) for for table related components when selecting a row.

Before (almost 2000 redraws):

![before](https://user-images.githubusercontent.com/513460/66652800-dfe18a00-ec36-11e9-986b-bf57c76ffc4e.gif)

https://recordit.co/3VnnA3bx4Z


After (82, which is still not perfect but now it's Widget that is the bottleneck)

![after](https://user-images.githubusercontent.com/513460/66652878-0b647480-ec37-11e9-8aac-92ef98f752d5.gif)

https://recordit.co/yE2TuYq8rU