### PR TITLE
First swing on improving tables performance

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -798,6 +798,12 @@ class Table extends Component {
     dispatch(openModal('Add new', windowType, 'window', tabId, rowId));
   };
 
+  openTableModal = () => {
+    const { dispatch, windowId, tabId } = this.props;
+
+    dispatch(openModal('Add new', windowId, 'window', tabId, 'NEW'));
+  };
+
   handleAdvancedEdit = (windowId, tabId, selected) => {
     const { dispatch } = this.props;
 
@@ -987,6 +993,8 @@ class Table extends Component {
       viewId,
       supportOpenRecord,
       focusOnFieldName,
+      modalVisible,
+      isGerman,
     } = this.props;
 
     const {
@@ -1030,6 +1038,8 @@ class Table extends Component {
           supportOpenRecord,
           item,
           focusOnFieldName,
+          modalVisible,
+          isGerman,
         }}
         dataHash={dataHash}
         key={`${i}-${viewId}`}
@@ -1065,12 +1075,7 @@ class Table extends Component {
         colspan={item.colspan}
         notSaved={item.saveStatus && !item.saveStatus.saved}
         getSizeClass={getSizeClass}
-        handleRowCollapse={() =>
-          this.handleRowCollapse(
-            item,
-            collapsedParentsRows.indexOf(item[keyProperty]) > -1
-          )
-        }
+        handleRowCollapse={this.handleRowCollapse}
         onItemChange={this.handleItemChange}
         onCopy={handleCopy}
       />
@@ -1193,7 +1198,7 @@ class Table extends Component {
           )}
           {!readonly && (
             <TableFilter
-              openTableModal={() => this.openModal(windowId, tabId, 'NEW')}
+              openTableModal={this.openTableModal}
               {...{
                 toggleFullScreen,
                 fullScreen,
@@ -1348,6 +1353,10 @@ Table.propTypes = propTypes;
 const mapStateToProps = state => ({
   allowShortcut: state.windowHandler.allowShortcut,
   allowOutsideClick: state.windowHandler.allowOutsideClick,
+  modalVisible: state.windowHandler.modal.visible,
+  isGerman: state.appHandler.me.language
+    ? state.appHandler.me.language.key.includes('de')
+    : false,
 });
 
 const clickOutsideConfig = {

--- a/src/components/table/TableCell.js
+++ b/src/components/table/TableCell.js
@@ -2,7 +2,6 @@ import Moment from 'moment-timezone';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
 import React, { PureComponent, createRef } from 'react';
-import { connect } from 'react-redux';
 import classnames from 'classnames';
 
 import MasterWidget from '../widget/MasterWidget';
@@ -410,16 +409,4 @@ TableCell.propTypes = {
   isGerman: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  modalVisible: state.windowHandler.modal.visible,
-  isGerman: state.appHandler.me.language
-    ? state.appHandler.me.language.key.includes('de')
-    : false,
-});
-
-export default connect(
-  mapStateToProps,
-  null,
-  null,
-  { forwardRef: true }
-)(TableCell);
+export default TableCell;

--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
-import { connect } from 'react-redux';
 import classnames from 'classnames';
 import { merge } from 'lodash';
 
@@ -360,6 +359,8 @@ class TableItem extends PureComponent {
       colspan,
       viewId,
       keyProperty,
+      modalVisible,
+      isGerman,
       isSelected,
       focusOnFieldName,
     } = this.props;
@@ -425,6 +426,8 @@ class TableItem extends PureComponent {
                   supportFieldEdit,
                   handleRightClick,
                   keyProperty,
+                  modalVisible,
+                  isGerman,
                 }}
                 ref={c => {
                   if (c && isSelected) {
@@ -502,6 +505,12 @@ class TableItem extends PureComponent {
     handleSelect(this.nestedSelect(elem).concat([id]));
   };
 
+  onRowCollapse = () => {
+    const { item, collapsed, handleRowCollapse } = this.props;
+
+    handleRowCollapse(item, collapsed);
+  };
+
   getIconClassName = huType => {
     switch (huType) {
       case 'LU':
@@ -527,7 +536,7 @@ class TableItem extends PureComponent {
       includedDocuments,
       rowId,
       collapsed,
-      handleRowCollapse,
+      // onRowCollapse,
       collapsible,
     } = this.props;
 
@@ -565,12 +574,12 @@ class TableItem extends PureComponent {
         {includedDocuments && collapsible ? (
           collapsed ? (
             <i
-              onClick={handleRowCollapse}
+              onClick={this.onRowCollapse}
               className="meta-icon-plus indent-collapse-icon"
             />
           ) : (
             <i
-              onClick={handleRowCollapse}
+              onClick={this.onRowCollapse}
               className="meta-icon-minus indent-collapse-icon"
             />
           )
@@ -589,7 +598,6 @@ class TableItem extends PureComponent {
 
   render() {
     const {
-      key,
       isSelected,
       odd,
       indentSupported,
@@ -605,7 +613,6 @@ class TableItem extends PureComponent {
     return (
       <WithMobileDoubleTap>
         <tr
-          key={key}
           onClick={this.handleClick}
           onDoubleClick={this.handleDoubleClick}
           className={classnames({
@@ -630,8 +637,8 @@ class TableItem extends PureComponent {
 
 TableItem.propTypes = {
   cols: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  item: PropTypes.object.isRequired,
   handleSelect: PropTypes.func,
   onDoubleClick: PropTypes.func,
   indentSupported: PropTypes.bool,
@@ -643,7 +650,6 @@ TableItem.propTypes = {
   odd: PropTypes.number,
   caption: PropTypes.string,
   dataHash: PropTypes.string.isRequired,
-  key: PropTypes.string,
   changeListenOnTrue: PropTypes.func,
   handleRowCollapse: PropTypes.func,
   handleRightClick: PropTypes.func,
@@ -669,9 +675,4 @@ TableItem.propTypes = {
   focusOnFieldName: PropTypes.string,
 };
 
-export default connect(
-  false,
-  false,
-  false,
-  { forwardRef: true }
-)(TableItem);
+export default TableItem;


### PR DESCRIPTION
Removed some unnecessary anonymous functions, disconnected `TableCell` from redux state. This alone already cuts the amount of redraws by 3x.

Related to #2473 