### PR TITLE
Suppress Table key handlers with control keys

### DIFF
--- a/src/components/table/TableItem.js
+++ b/src/components/table/TableItem.js
@@ -141,7 +141,7 @@ class TableItem extends PureComponent {
         break;
       default: {
         const inp = String.fromCharCode(e.keyCode);
-        if (/[a-zA-Z0-9]/.test(inp)) {
+        if (/[a-zA-Z0-9]/.test(inp) && !e.ctrlKey && !e.altKey) {
           this.listenOnKeysTrue();
 
           this.handleEditProperty(e, property, true, widgetData, true);
@@ -673,6 +673,9 @@ TableItem.propTypes = {
   includedDocuments: PropTypes.array,
   contextType: PropTypes.any,
   focusOnFieldName: PropTypes.string,
+  modalVisible: PropTypes.bool,
+  isGerman: PropTypes.bool,
+  keyProperty: PropTypes.string,
 };
 
 export default TableItem;


### PR DESCRIPTION
If `ctrl/cmd/alt/opt` is pressed, the usual TableItem key handler for editing field value should follow through as this tells us user is going for a shortcut.

Related to #2477 