### PR TITLE
Add languages into the redux store #2632

### DIFF
--- a/src/actions/AppActions.js
+++ b/src/actions/AppActions.js
@@ -374,6 +374,13 @@ export function userSessionUpdate(me) {
   };
 }
 
+export function setLanguages(data) {
+  return {
+    type: types.SET_LANGUAGES,
+    data,
+  };
+}
+
 export function initKeymap(keymap) {
   return {
     type: types.INIT_KEYMAP,

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -75,7 +75,8 @@ class Header extends Component {
     if (
       prevProps.me.language !== undefined &&
       JSON.stringify(prevProps.me.language) !==
-        JSON.stringify(this.props.me.language)
+        JSON.stringify(this.props.me.language) &&
+      !Array.isArray(prevProps.me.language)
     ) {
       // Need to reload page completely when current locale gets changed
       window.location.reload(false);

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -487,3 +487,9 @@ export const DELETE_TOP_ACTIONS = 'DELETE_TOP_ACTIONS';
  * @type {string} removes tab's quick actions on unmount.
  */
 export const UPDATE_TAB_ROWS_DATA = 'UPDATE_TAB_ROWS_DATA';
+
+/**
+ * @constant
+ * @type {string} set languages in the app handler
+ */
+export const SET_LANGUAGES = 'SET_LANGUAGES';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -150,7 +150,9 @@ export default class App extends Component {
     getAvailableLang().then((response) => {
       const { defaultValue, values } = response.data;
       const valuesFlatten = values.map((item) => Object.keys(item)[0]);
-      store.dispatch(setLanguages(values));
+      if (!store.getState().appHandler.me.language) {
+        store.dispatch(setLanguages(values));
+      }
       const lang =
         valuesFlatten.indexOf(navigator.language) > -1
           ? navigator.language

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -13,6 +13,7 @@ import {
   setProcessSaved,
   initHotkeys,
   initKeymap,
+  setLanguages,
 } from '../actions/AppActions';
 import { getAvailableLang } from '../api';
 import { noConnection } from '../actions/WindowActions';
@@ -149,6 +150,7 @@ export default class App extends Component {
     getAvailableLang().then((response) => {
       const { defaultValue, values } = response.data;
       const valuesFlatten = values.map((item) => Object.keys(item)[0]);
+      store.dispatch(setLanguages(values));
       const lang =
         valuesFlatten.indexOf(navigator.language) > -1
           ? navigator.language

--- a/src/reducers/appHandler.js
+++ b/src/reducers/appHandler.js
@@ -33,6 +33,15 @@ export default function appHandler(state = initialState, action) {
         },
       };
 
+    case types.SET_LANGUAGES:
+      return {
+        ...state,
+        me: {
+          ...state.me,
+          language: action.data,
+        },
+      };
+
     case types.LOGIN_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
Adds the languages into the redux store. This is needed because the existing cypress tests were looking into these and they could not be found..thus tests failing.