### PR TITLE
Dev 2655 ux txt inputs limiting

### DIFF
--- a/src/__tests__/components/widget/CharacterLimitInfo.test.js
+++ b/src/__tests__/components/widget/CharacterLimitInfo.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import CharacterLimitInfo from '../../../components/widget/CharacterLimitInfo';
+
+describe('CharacterLimitInfo component', () => {
+  describe('rendering tests:', () => {
+    it('renders without errors', () => {
+      const wrapper = shallow(<CharacterLimitInfo charsTyped={40} maxLength={40} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('text-muted');
+    });
+
+    it('renders muted text when chars typed are near the max allowed limit', () => {
+      const wrapper = shallow(<CharacterLimitInfo charsTyped={35} maxLength={40} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('text-muted');
+    });
+
+    it('renders the red text when when chars typed are exceeding the max allowed limit', () => {
+      const wrapper = shallow(<CharacterLimitInfo charsTyped={41} maxLength={40} />);
+      const html = wrapper.html();
+
+      expect(html).toContain('text-danger');
+    });
+
+    it('does not render any muted text or error text if input chars is not near the max limit', () => {
+      const wrapper = shallow(<CharacterLimitInfo charsTyped={20} maxLength={40} />);
+      const html = wrapper.html();
+      expect(html).not.toContain('text-muted');
+      expect(html).not.toContain('text-danger');
+    });
+  });
+});
+
+

--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -501,7 +501,7 @@ describe('RawWidget component', () => {
         target: { value: 'This is a test' },
       },
     );
-    console.log(wrapper.debug())
+
     const html = wrapper.html();
     expect(html).not.toContain('border-danger');
   });
@@ -526,7 +526,7 @@ describe('RawWidget component', () => {
         target: { value: 'This is a test for checking the limit on inputs' },
       },
     );
-    console.log(wrapper.debug())
+
     const html = wrapper.html();
     expect(html).toContain('border-danger');
   });

--- a/src/__tests__/components/widget/RawWidget.test.js
+++ b/src/__tests__/components/widget/RawWidget.test.js
@@ -482,4 +482,52 @@ describe('RawWidget component', () => {
       expect(preventDefaultSpy).not.toHaveBeenCalled();
     });
   });
+
+  it('Shows a normal border when input does not exceeds the char limit', () => {
+    const props = createDummyProps(
+      {
+        ...fixtures.text.layout1,
+        widgetData: [{ ...fixtures.text.data1 }],
+        maxLength: 40,
+      },
+    );
+
+    const wrapper = shallow(<RawWidget {...props} />);
+
+    wrapper.find('input').simulate(
+      'keyDown',
+      {
+        key: 'Alt',
+        target: { value: 'This is a test' },
+      },
+    );
+    console.log(wrapper.debug())
+    const html = wrapper.html();
+    expect(html).not.toContain('border-danger');
+  });
+
+
+
+  it('Shows a red border when input exceeds the char limit', () => {
+    const props = createDummyProps(
+      {
+        ...fixtures.text.layout1,
+        widgetData: [{ ...fixtures.text.data1 }],
+        maxLength: 40,
+      },
+    );
+
+    const wrapper = shallow(<RawWidget {...props} />);
+
+    wrapper.find('input').simulate(
+      'keyDown',
+      {
+        key: 'Alt',
+        target: { value: 'This is a test for checking the limit on inputs' },
+      },
+    );
+    console.log(wrapper.debug())
+    const html = wrapper.html();
+    expect(html).toContain('border-danger');
+  });
 });

--- a/src/components/widget/CharacterLimitInfo.js
+++ b/src/components/widget/CharacterLimitInfo.js
@@ -6,7 +6,7 @@ const CharacterLimitInfo = ({ charsTyped, maxLength }) => {
   const NO_OF_CHARS_BEFORE_MAX_REACHED = 10;
   const displayGrayedLimit =
     maxLength - charsTyped < NO_OF_CHARS_BEFORE_MAX_REACHED;
-  const displayErrorLimit = charsTyped >= maxLength;
+  const displayErrorLimit = charsTyped > maxLength;
 
   return (
     <Fragment>

--- a/src/components/widget/CharacterLimitInfo.js
+++ b/src/components/widget/CharacterLimitInfo.js
@@ -1,0 +1,35 @@
+import React, { Fragment } from 'react';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+const CharacterLimitInfo = ({ charsTyped, maxLength }) => {
+  const NO_OF_CHARS_BEFORE_MAX_REACHED = 10;
+  const displayGrayedLimit =
+    maxLength - charsTyped < NO_OF_CHARS_BEFORE_MAX_REACHED;
+  const displayErrorLimit = charsTyped >= maxLength;
+
+  return (
+    <Fragment>
+      {displayGrayedLimit && (
+        <div>
+          <div
+            className={classnames(
+              'float-right',
+              { 'text-muted': displayGrayedLimit && !displayErrorLimit },
+              { 'text-danger': displayErrorLimit }
+            )}
+          >
+            {`${charsTyped} / ${maxLength} Characters`}
+          </div>
+        </div>
+      )}
+    </Fragment>
+  );
+};
+
+CharacterLimitInfo.propTypes = {
+  charsTyped: PropTypes.number,
+  maxLength: PropTypes.number,
+};
+
+export default CharacterLimitInfo;

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -164,6 +164,19 @@ export class RawWidget extends Component {
   };
 
   /**
+   * @method updateTypedCharacters
+   * @summary updates in the state the number of charactes typed
+   * @param {typedText} string
+   */
+  updateTypedCharacters = (typedText) => {
+    const { fieldName } = this.props;
+    let existingCharsTyped = { ...this.state.charsTyped };
+    existingCharsTyped[fieldName] = typedText.length;
+    this.setState({ charsTyped: existingCharsTyped });
+    return true;
+  };
+
+  /**
    * @method handleKeyDown
    * @summary key handler for the widgets. For number fields we're suppressing up/down
    *          arrows to enable table row navigation
@@ -174,7 +187,8 @@ export class RawWidget extends Component {
   handleKeyDown = (e, property, value) => {
     const { lastFormField, widgetType, closeTableField } = this.props;
     const { key } = e;
-
+    this.updateTypedCharacters(e.target.value);
+ 
     // for number fields submit them automatically on up/down arrow pressed and blur the field
     const NumberWidgets = ImmutableList([
       'Integer',
@@ -253,8 +267,13 @@ export class RawWidget extends Component {
    * @param {*} isForce
    */
   handlePatch = (property, value, id, valueTo, isForce) => {
-    const { handlePatch, inProgress, widgetType } = this.props;
+    const { handlePatch, inProgress, widgetType, maxLength } = this.props;
     const willPatch = this.willPatch(property, value, valueTo);
+
+    if (widgetType === 'LongText' || widgetType === 'Text') {
+      value = value.substring(0, maxLength);
+      this.updateTypedCharacters(value);
+    }
 
     // Do patch only when value is not equal state
     // or cache is set and it is not equal value
@@ -390,11 +409,13 @@ export class RawWidget extends Component {
       dateFormat,
       initialFocus,
       timeZone,
+      fieldName,
+      maxLength,
     } = this.props;
 
     let widgetValue = data != null ? data : widgetData[0].value;
-    const { isEdited } = this.state;
-
+    const { isEdited, charsTyped } = this.state;
+   
     // TODO: API SHOULD RETURN THE SAME PROPERTIES FOR FILTERS
     const widgetField = filterWidget
       ? fields[0].parameterName
@@ -430,7 +451,9 @@ export class RawWidget extends Component {
       onFocus: this.handleFocus,
       tabIndex: tabIndex,
       onChange: (e) =>
-        handleChange && handleChange(widgetField, e.target.value),
+        handleChange &&
+        this.updateTypedCharacters(e.target.value) &&
+        handleChange(widgetField, e.target.value),
       onBlur: (e) => this.handleBlur(widgetField, e.target.value, id),
       onKeyDown: (e) =>
         this.handleKeyDown(e, widgetField, e.target.value, widgetType),
@@ -763,6 +786,10 @@ export class RawWidget extends Component {
               }),
               {
                 'input-focused': isEdited,
+              },
+              {
+                'border-danger':
+                  charsTyped && charsTyped[fieldName] > maxLength,
               }
             )}
           >
@@ -780,6 +807,10 @@ export class RawWidget extends Component {
               }),
               {
                 'input-focused': isEdited,
+              },
+              {
+                'border-danger':
+                  charsTyped && charsTyped[fieldName] > maxLength,
               }
             )}
           >

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -24,6 +24,7 @@ import Image from './Image';
 import Tooltips from '../tooltips/Tooltips';
 import Labels from './Labels';
 import Link from './Link';
+import CharacterLimitInfo from './CharacterLimitInfo';
 import List from './List/List';
 import Lookup from './Lookup/Lookup';
 
@@ -188,7 +189,7 @@ export class RawWidget extends Component {
     const { lastFormField, widgetType, closeTableField } = this.props;
     const { key } = e;
     this.updateTypedCharacters(e.target.value);
- 
+
     // for number fields submit them automatically on up/down arrow pressed and blur the field
     const NumberWidgets = ImmutableList([
       'Integer',
@@ -415,7 +416,7 @@ export class RawWidget extends Component {
 
     let widgetValue = data != null ? data : widgetData[0].value;
     const { isEdited, charsTyped } = this.state;
-   
+
     // TODO: API SHOULD RETURN THE SAME PROPERTIES FOR FILTERS
     const widgetField = filterWidget
       ? fields[0].parameterName
@@ -460,7 +461,7 @@ export class RawWidget extends Component {
       title: widgetValue,
       id,
     };
-
+    const showErrorBorder = charsTyped && charsTyped[fieldName] > maxLength;
     let selectedValue = widgetData[0].value
       ? widgetData[0].value
       : widgetData[0].defaultValue;
@@ -779,42 +780,56 @@ export class RawWidget extends Component {
         );
       case 'Text':
         return (
-          <div
-            className={classnames(
-              this.getClassNames({
-                icon: true,
-              }),
-              {
-                'input-focused': isEdited,
-              },
-              {
-                'border-danger':
-                  charsTyped && charsTyped[fieldName] > maxLength,
-              }
+          <div>
+            <div
+              className={classnames(
+                this.getClassNames({
+                  icon: true,
+                }),
+                {
+                  'input-focused': isEdited,
+                },
+                {
+                  'border-danger': showErrorBorder,
+                }
+              )}
+            >
+              <input {...widgetProperties} type="text" />
+              {icon && <i className="meta-icon-edit input-icon-right" />}
+            </div>
+            {charsTyped && charsTyped[fieldName] && (
+              <CharacterLimitInfo
+                charsTyped={charsTyped[fieldName]}
+                maxLength={maxLength}
+              />
             )}
-          >
-            <input {...widgetProperties} type="text" />
-            {icon && <i className="meta-icon-edit input-icon-right" />}
           </div>
         );
       case 'LongText':
         return (
-          <div
-            className={classnames(
-              this.getClassNames({
-                icon: false,
-                forcedPrimary: true,
-              }),
-              {
-                'input-focused': isEdited,
-              },
-              {
-                'border-danger':
-                  charsTyped && charsTyped[fieldName] > maxLength,
-              }
+          <div>
+            <div
+              className={classnames(
+                this.getClassNames({
+                  icon: false,
+                  forcedPrimary: true,
+                }),
+                {
+                  'input-focused': isEdited,
+                },
+                {
+                  'border-danger': showErrorBorder,
+                }
+              )}
+            >
+              <textarea {...widgetProperties} />
+            </div>
+            {charsTyped && charsTyped[fieldName] && (
+              <CharacterLimitInfo
+                charsTyped={charsTyped[fieldName]}
+                maxLength={maxLength}
+              />
             )}
-          >
-            <textarea {...widgetProperties} />
           </div>
         );
       case 'Password':

--- a/src/components/widget/RawWidget.js
+++ b/src/components/widget/RawWidget.js
@@ -797,7 +797,7 @@ export class RawWidget extends Component {
               <input {...widgetProperties} type="text" />
               {icon && <i className="meta-icon-edit input-icon-right" />}
             </div>
-            {charsTyped && charsTyped[fieldName] && (
+            {charsTyped && charsTyped[fieldName] >= 0 && (
               <CharacterLimitInfo
                 charsTyped={charsTyped[fieldName]}
                 maxLength={maxLength}
@@ -824,7 +824,7 @@ export class RawWidget extends Component {
             >
               <textarea {...widgetProperties} />
             </div>
-            {charsTyped && charsTyped[fieldName] && (
+            {charsTyped && charsTyped[fieldName] >= 0 && (
               <CharacterLimitInfo
                 charsTyped={charsTyped[fieldName]}
                 maxLength={maxLength}


### PR DESCRIPTION
- For multiline text fields and text fields show a message with quantity of available characters underneath the field itself. Example: "98 / 100 Characters"
- show this quantity as soon the user gets "near" to the max possible quantity and  shows red when exceeded
- In cases the user types more than the allowed quantity then show the whole field in a signal color
- don't allow saving without proper quantity of characters. means don't save the text and cut-off the text silently